### PR TITLE
Expose function to access build logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ The plugin provides built-in tools through the `DefaultMcpServer` class:
 - `getJob`: Get a Jenkins job by its full path.
 - `getAllJobs`: Get a list of all Jenkins jobs.
 - `triggerBuild`: Trigger a build of a job.
-- `getBuildLogs`: Retrieves the full log for a specific build of the last build of a Jenkins job.
+- `getBuildLog`: Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job.
+- `getBuildLogLength`: Retrieves the log length for a specific build or the last build of a Jenkins job.
 
 ### Extending MCP Capabilities
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ The plugin provides built-in tools through the `DefaultMcpServer` class:
 - `getAllJobs`: Get a list of all Jenkins jobs.
 - `triggerBuild`: Trigger a build of a job.
 - `getBuildLog`: Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job.
-- `getBuildLogLength`: Retrieves the log length for a specific build or the last build of a Jenkins job.
 
 ### Extending MCP Capabilities
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The plugin provides built-in tools through the `DefaultMcpServer` class:
 - `getJob`: Get a Jenkins job by its full path.
 - `getAllJobs`: Get a list of all Jenkins jobs.
 - `triggerBuild`: Trigger a build of a job.
+- `getBuildLogs`: Retrieves the full log for a specific build of the last build of a Jenkins job.
 
 ### Extending MCP Capabilities
 

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.mcp.server.extensions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import hudson.Extension;
+import hudson.model.Job;
+import io.jenkins.plugins.mcp.server.McpServerExtension;
+import io.jenkins.plugins.mcp.server.annotation.Tool;
+import io.jenkins.plugins.mcp.server.annotation.ToolParam;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.List;
+import jenkins.model.Jenkins;
+
+@Extension
+public class BuildLogsExtension implements McpServerExtension {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Tool(
+            description =
+                    "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job,"
+                            + " as well as a boolean value indicating whether there is more content to retrieve")
+    public ObjectNode getBuildLog(
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
+                    String buildNumber,
+            @ToolParam(description = "The number of lines to return (optional, if not provided, returns 100 lines)")
+                    int length,
+            @ToolParam(
+                            description =
+                                    "The offset (optional, if not provided, returns the first line). Negative values function as 'from the end', with -1 meaning starting with the last line")
+                    long offset) {
+        if (length == 0) length = 100;
+        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
+        if (job == null) return null;
+        List<String> lines = null;
+
+        try (BufferedReader reader = new BufferedReader(
+                (buildNumber == null || buildNumber.isEmpty())
+                        ? job.getLastBuild().getLogReader()
+                        : job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogReader())) {
+
+            List<String> allLines = reader.lines().toList();
+            long actualOffset = offset;
+            if (offset < 0) actualOffset = Math.max(0, allLines.size() + offset);
+            int endIndex = (int) Math.min(actualOffset + length, allLines.size());
+            lines = allLines.subList((int) actualOffset, endIndex);
+            boolean hasMoreContent = endIndex < allLines.size();
+
+            ObjectNode jsonResponse = mapper.createObjectNode();
+            jsonResponse.put("hasMoreContent", hasMoreContent);
+            jsonResponse.set("lines", mapper.valueToTree(lines));
+            return jsonResponse;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -32,10 +32,8 @@ import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import jakarta.annotation.Nullable;
-
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.Comparator;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -129,37 +127,44 @@ public class DefaultMcpServer implements McpServerExtension {
     public long getBuildLogLength(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
-            String buildNumber) {
+                    String buildNumber) {
         var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
         if (job != null) {
-            try (BufferedReader reader = new BufferedReader((buildNumber == null || buildNumber.isEmpty())
-                    ? job.getLastBuild().getLogReader()
-                    : job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogReader())) {
+            try (BufferedReader reader = new BufferedReader(
+                    (buildNumber == null || buildNumber.isEmpty())
+                            ? job.getLastBuild().getLogReader()
+                            : job.getBuildByNumber(Integer.parseInt(buildNumber))
+                                    .getLogReader())) {
 
                 return reader.lines().count();
-            } catch (Exception e) {
+            } catch (IOException e) {
                 return 0;
             }
         }
         return 0;
     }
 
-    @Tool(description = "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job")
+    @Tool(
+            description =
+                    "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job")
     public List<String> getBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
                     String buildNumber,
-            @ToolParam(description = "The number of lines to return (optional, if not provided, returns 100 lines)") int length,
+            @ToolParam(description = "The number of lines to return (optional, if not provided, returns 100 lines)")
+                    int length,
             @ToolParam(description = "The offset (optional, if not provided, returns the first line)") long offset) {
         if (length == 0) length = 100;
         var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
         if (job != null) {
-            try (BufferedReader reader = new BufferedReader((buildNumber == null || buildNumber.isEmpty())
-                    ? job.getLastBuild().getLogReader()
-                    : job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogReader())) {
+            try (BufferedReader reader = new BufferedReader(
+                    (buildNumber == null || buildNumber.isEmpty())
+                            ? job.getLastBuild().getLogReader()
+                            : job.getBuildByNumber(Integer.parseInt(buildNumber))
+                                    .getLogReader())) {
 
                 return reader.lines().skip(offset).limit(length).toList();
-            } catch (Exception e) {
+            } catch (IOException e) {
                 return null;
             }
         }

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -32,8 +32,6 @@ import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import jakarta.annotation.Nullable;
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -121,53 +119,5 @@ public class DefaultMcpServer implements McpServerExtension {
         } else {
             return List.of();
         }
-    }
-
-    @Tool(description = "Retrieves the log length for a specific build or the last build of a Jenkins job")
-    public long getBuildLogLength(
-            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
-            @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
-                    String buildNumber) {
-        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
-        if (job != null) {
-            try (BufferedReader reader = new BufferedReader(
-                    (buildNumber == null || buildNumber.isEmpty())
-                            ? job.getLastBuild().getLogReader()
-                            : job.getBuildByNumber(Integer.parseInt(buildNumber))
-                                    .getLogReader())) {
-
-                return reader.lines().count();
-            } catch (IOException e) {
-                return 0;
-            }
-        }
-        return 0;
-    }
-
-    @Tool(
-            description =
-                    "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job")
-    public List<String> getBuildLog(
-            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
-            @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
-                    String buildNumber,
-            @ToolParam(description = "The number of lines to return (optional, if not provided, returns 100 lines)")
-                    int length,
-            @ToolParam(description = "The offset (optional, if not provided, returns the first line)") long offset) {
-        if (length == 0) length = 100;
-        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
-        if (job != null) {
-            try (BufferedReader reader = new BufferedReader(
-                    (buildNumber == null || buildNumber.isEmpty())
-                            ? job.getLastBuild().getLogReader()
-                            : job.getBuildByNumber(Integer.parseInt(buildNumber))
-                                    .getLogReader())) {
-
-                return reader.lines().skip(offset).limit(length).toList();
-            } catch (IOException e) {
-                return null;
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -27,12 +27,12 @@
 package io.jenkins.plugins.mcp.server.extensions;
 
 import hudson.Extension;
-import hudson.console.AnnotatedLargeText;
 import hudson.model.*;
 import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import jakarta.annotation.Nullable;
+import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -123,15 +123,17 @@ public class DefaultMcpServer implements McpServerExtension {
     }
 
     @Tool(description = "Retrieves the full log for a specific build of the last build of a Jenkins job")
-    public AnnotatedLargeText getBuildLog(
+    public List<String> getBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
-            @ToolParam(description = "The build number (optional, if not provided, returns the last build)") String buildNumber) {
+            @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
+                    String buildNumber)
+            throws IOException {
         var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
         if (job != null) {
             if (buildNumber == null || buildNumber.isEmpty()) {
-                return job.getLastBuild().getLogText();
+                return job.getLastBuild().getLog(Integer.MAX_VALUE);
             } else {
-                return job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogText();
+                return job.getBuildByNumber(Integer.parseInt(buildNumber)).getLog(Integer.MAX_VALUE);
             }
         }
         return null;

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -27,6 +27,7 @@
 package io.jenkins.plugins.mcp.server.extensions;
 
 import hudson.Extension;
+import hudson.console.AnnotatedLargeText;
 import hudson.model.*;
 import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
@@ -42,7 +43,7 @@ public class DefaultMcpServer implements McpServerExtension {
 
     @Tool(description = "Get a specific build or the last build of a Jenkins job")
     public Run getBuild(
-            @ToolParam(description = "Job full nam of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
                     @ToolParam(
                             description = "Build number (optional, if not provided, returns the last build)",
@@ -119,5 +120,20 @@ public class DefaultMcpServer implements McpServerExtension {
         } else {
             return List.of();
         }
+    }
+
+    @Tool(description = "Retrieves the full log for a specific build of the last build of a Jenkins job")
+    public AnnotatedLargeText getBuildLog(
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @ToolParam(description = "The build number (optional, if not provided, returns the last build)") String buildNumber) {
+        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
+        if (job != null) {
+            if (buildNumber == null || buildNumber.isEmpty()) {
+                return job.getLastBuild().getLogText();
+            } else {
+                return job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogText();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -32,7 +32,10 @@ import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import jakarta.annotation.Nullable;
+
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.Comparator;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -122,18 +125,42 @@ public class DefaultMcpServer implements McpServerExtension {
         }
     }
 
-    @Tool(description = "Retrieves the full log for a specific build of the last build of a Jenkins job")
+    @Tool(description = "Retrieves the log length for a specific build or the last build of a Jenkins job")
+    public long getBuildLogLength(
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
+            String buildNumber) {
+        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
+        if (job != null) {
+            try (BufferedReader reader = new BufferedReader((buildNumber == null || buildNumber.isEmpty())
+                    ? job.getLastBuild().getLogReader()
+                    : job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogReader())) {
+
+                return reader.lines().count();
+            } catch (Exception e) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    @Tool(description = "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job")
     public List<String> getBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "The build number (optional, if not provided, returns the last build)")
-                    String buildNumber)
-            throws IOException {
+                    String buildNumber,
+            @ToolParam(description = "The number of lines to return (optional, if not provided, returns 100 lines)") int length,
+            @ToolParam(description = "The offset (optional, if not provided, returns the first line)") long offset) {
+        if (length == 0) length = 100;
         var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
         if (job != null) {
-            if (buildNumber == null || buildNumber.isEmpty()) {
-                return job.getLastBuild().getLog(Integer.MAX_VALUE);
-            } else {
-                return job.getBuildByNumber(Integer.parseInt(buildNumber)).getLog(Integer.MAX_VALUE);
+            try (BufferedReader reader = new BufferedReader((buildNumber == null || buildNumber.isEmpty())
+                    ? job.getLastBuild().getLogReader()
+                    : job.getBuildByNumber(Integer.parseInt(buildNumber)).getLogReader())) {
+
+                return reader.lines().skip(offset).limit(length).toList();
+            } catch (Exception e) {
+                return null;
             }
         }
         return null;

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
@@ -253,8 +253,8 @@ class EndpointTest {
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build()) {
             client.initialize();
-            McpSchema.CallToolRequest request =
-                    new McpSchema.CallToolRequest("getBuildLogLength", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 0));
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuildLogLength", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 0));
 
             var response = client.callTool(request);
             assertThat(response.isError()).isFalse();
@@ -286,8 +286,8 @@ class EndpointTest {
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build()) {
             client.initialize();
-            McpSchema.CallToolRequest request =
-                    new McpSchema.CallToolRequest("getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 0));
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 0));
 
             var response = client.callTool(request);
             assertThat(response.isError()).isFalse();
@@ -319,8 +319,8 @@ class EndpointTest {
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build()) {
             client.initialize();
-            McpSchema.CallToolRequest request =
-                    new McpSchema.CallToolRequest("getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 1));
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 1));
 
             var response = client.callTool(request);
             assertThat(response.isError()).isFalse();
@@ -352,8 +352,8 @@ class EndpointTest {
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build()) {
             client.initialize();
-            McpSchema.CallToolRequest request =
-                    new McpSchema.CallToolRequest("getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 3, "offset", 1));
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuildLog", Map.of("jobFullName", project.getFullName(), "length", 3, "offset", 1));
 
             var response = client.callTool(request);
             assertThat(response.isError()).isFalse();

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
@@ -236,6 +236,39 @@ class EndpointTest {
     }
 
     @Test
+    void testMcpToolCallGetBuildLogs(JenkinsRule jenkins) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
+        project.setDefinition(new CpsFlowDefinition("", true));
+        var build = project.scheduleBuild2(0).get();
+
+        var url = jenkins.getURL();
+        var baseUrl = url.toString();
+
+        var transport = HttpClientSseClientTransport.builder(baseUrl)
+                .sseEndpoint(MCP_SERVER_SSE)
+                .build();
+
+        try (var client = McpClient.sync(transport)
+                .requestTimeout(Duration.ofSeconds(500))
+                .capabilities(McpSchema.ClientCapabilities.builder().build())
+                .build()) {
+            client.initialize();
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("getBuildLog", Map.of("jobFullName", project.getFullName()));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(4);
+            response.content().forEach(content -> {
+                assertThat(content.type()).isEqualTo("text");
+                assertThat(content).isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                    assertThat(textContent.text()).isNotEmpty();
+                });
+            });
+        }
+    }
+
+    @Test
     void testMcpToolCallSimpleJson(JenkinsRule jenkins) throws Exception {
 
         var url = jenkins.getURL();

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndpointTest.java
@@ -40,13 +40,9 @@ import io.modelcontextprotocol.spec.McpSchema;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -237,84 +233,6 @@ class EndpointTest {
                         });
             }
         }
-    }
-
-    @Test
-    void testMcpToolCallGetBuildLogLength(JenkinsRule jenkins) throws Exception {
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
-        project.setDefinition(new CpsFlowDefinition("", true));
-        var build = project.scheduleBuild2(0).get();
-
-        var url = jenkins.getURL();
-        var baseUrl = url.toString();
-
-        var transport = HttpClientSseClientTransport.builder(baseUrl)
-                .sseEndpoint(MCP_SERVER_SSE)
-                .build();
-
-        try (var client = McpClient.sync(transport)
-                .requestTimeout(Duration.ofSeconds(500))
-                .capabilities(McpSchema.ClientCapabilities.builder().build())
-                .build()) {
-            client.initialize();
-            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
-                    "getBuildLogLength", Map.of("jobFullName", project.getFullName(), "length", 100, "offset", 0));
-
-            var response = client.callTool(request);
-            assertThat(response.isError()).isFalse();
-            assertThat(response.content()).hasSize(1);
-            response.content().forEach(content -> {
-                assertThat(content.type()).isEqualTo("text");
-                assertThat(content).isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
-                    assertThat(textContent.text()).isEqualTo("4");
-                });
-            });
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("buildLogTestParameters")
-    void testMcpToolCallGetBuildLog(int length, long offset, int expectedContentSize, JenkinsRule jenkins)
-            throws Exception {
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
-        project.setDefinition(new CpsFlowDefinition("", true));
-        var build = project.scheduleBuild2(0).get();
-
-        var url = jenkins.getURL();
-        var baseUrl = url.toString();
-
-        var transport = HttpClientSseClientTransport.builder(baseUrl)
-                .sseEndpoint(MCP_SERVER_SSE)
-                .build();
-
-        try (var client = McpClient.sync(transport)
-                .requestTimeout(Duration.ofSeconds(500))
-                .capabilities(McpSchema.ClientCapabilities.builder().build())
-                .build()) {
-            client.initialize();
-
-            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
-                    "getBuildLog", Map.of("jobFullName", project.getFullName(), "length", length, "offset", offset));
-
-            var response = client.callTool(request);
-            assertThat(response.isError()).isFalse();
-            assertThat(response.content()).hasSize(expectedContentSize);
-            response.content().forEach(content -> {
-                assertThat(content.type()).isEqualTo("text");
-                assertThat(content).isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
-                    assertThat(textContent.text()).isNotEmpty();
-                });
-            });
-        }
-    }
-
-    static Stream<Arguments> buildLogTestParameters() {
-        return Stream.of(
-                // length, offset, expectedContentSize
-                Arguments.of(100, 0, 4), // Original test case
-                Arguments.of(100, 1, 3), // With offset
-                Arguments.of(3, 1, 3) // With limit
-                );
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogExtensionTest.java
@@ -1,0 +1,88 @@
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static io.jenkins.plugins.mcp.server.Endpoint.MCP_SERVER_SSE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class BuildLogExtensionTest {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @ParameterizedTest
+    @MethodSource("buildLogTestParameters")
+    void testMcpToolCallGetBuildLog(
+            int length, long offset, int expectedContentSize, boolean hasMoreContent, JenkinsRule jenkins)
+            throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
+        project.setDefinition(new CpsFlowDefinition("", true));
+        var build = project.scheduleBuild2(0).get();
+
+        var url = jenkins.getURL();
+        var baseUrl = url.toString();
+
+        var transport = HttpClientSseClientTransport.builder(baseUrl)
+                .sseEndpoint(MCP_SERVER_SSE)
+                .build();
+
+        try (var client = McpClient.sync(transport)
+                .requestTimeout(Duration.ofSeconds(500))
+                .capabilities(McpSchema.ClientCapabilities.builder().build())
+                .build()) {
+            client.initialize();
+
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuildLog", Map.of("jobFullName", project.getFullName(), "length", length, "offset", offset));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(1);
+            response.content().forEach(content -> {
+                assertThat(content.type()).isEqualTo("text");
+                assertThat(content).isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                    JsonNode jsonNode = null;
+                    try {
+                        jsonNode = objectMapper.readTree(textContent.text());
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    assertThat(jsonNode.has("hasMoreContent")).isTrue();
+                    assertThat(hasMoreContent).matches(expected -> expected == hasMoreContent);
+
+                    JsonNode linesArray = jsonNode.get("lines");
+                    assertThat(linesArray.size()).isEqualTo(expectedContentSize);
+                    for (JsonNode lineNode : linesArray) {
+                        assertThat(lineNode.asText().trim()).isNotEmpty();
+                    }
+                });
+            });
+        }
+    }
+
+    static Stream<Arguments> buildLogTestParameters() {
+        return Stream.of(
+                // length, offset, expectedContentSize
+                Arguments.of(100, 0, 4, false), // Original test case
+                Arguments.of(100, 1, 3, false), // With offset
+                Arguments.of(3, 0, 3, true), // With limit
+                Arguments.of(100, -1, 1, false), // With negative offset
+                Arguments.of(3, -4, 3, true) // With negative offset and limit
+                );
+    }
+}


### PR DESCRIPTION
Adds an extension to get build logs. Includes pagination, and negative indexing
adds https://github.com/jenkinsci/mcp-server-plugin/issues/8

### Testing done
Unit tests, Installed on jenkins instance and validated it works

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
