### PR TITLE
Update jenkins baseline to 2.942.3 and BOM to 5353.v3dec76e40169

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <revision>0</revision>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.492</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
@@ -50,7 +50,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4770.v9a_2b_7a_9d8b_7f</version>
+        <version>5353.v3dec76e40169</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Right now `master` is broken because ci.jenkins.io has updated `git` to 2.51, this made changeset relates tests in `JobScmExtensionTest` fail as changesets were not detected. See  https://issues.jenkins.io/browse/JENKINS-76004 and https://github.com/jenkinsci/bom/pull/5630 for further details.

This PR updates jenkins baseline to `2.492` and the BOM version so it can pick the proper git-client version. Also `2.472` is not actively maintained in the BOM, so is best to update.

I am not sure if you want to do a bigger bump in the jenkins baseline, so I went with the smaller one possible.

### Testing done

`mvn verify`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
