### PR TITLE
add a friendly message when trying to access /mcp-server/mcp

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -230,7 +230,20 @@ public class Endpoint extends CrumbExclusion implements RootAction {
             if (isSSERequest(servletRequest)) {
                 handleSSE(servletRequest, servletResponse);
             } else if (isStreamableRequest(servletRequest)) {
-                handleMessage(servletRequest, servletResponse, httpServletStreamableServerTransportProvider);
+                if (servletRequest instanceof HttpServletRequest req
+                        && req.getMethod().equalsIgnoreCase("GET")) {
+                    // Serve friendly error page for GET requests to /mcp-server/mcp
+                    HttpServletResponse resp = (HttpServletResponse) servletResponse;
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    resp.setContentType("text/html;charset=UTF-8");
+                    resp.getWriter()
+                            .write(
+                                    "<html><head><title>Model Context Protocol Endpoint</title></head>"
+                                            + "<body><h2>This endpoint is designed for an AI agent using the Model Context Protocol.</h2></body></html>");
+                    resp.getWriter().flush();
+                } else {
+                    handleMessage(servletRequest, servletResponse, httpServletStreamableServerTransportProvider);
+                }
             } else {
                 filterChain.doFilter(servletRequest, servletResponse);
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Some users might try to access directly in the browser <jenkins_url>/mcp-server/mcp and get an error (400 - Bad request).

With this modifiation, a friendlier message is displayed:

<img width="865" height="115" alt="Screenshot from 2025-10-31 10-43-16" src="https://github.com/user-attachments/assets/a6c561d1-5544-411a-9dd2-1f47602fb1e5" />


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
