### PR TITLE
feat: Introduce ThreadLocal JenkinsMcpContext for tool calls

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -90,6 +90,8 @@ public class Endpoint extends CrumbExclusion implements RootAction {
 
     public static final String MCP_SERVER_MESSAGE = MCP_SERVER + MESSAGE_ENDPOINT;
     public static final String USER_ID = Endpoint.class.getName() + ".userId";
+    public static final String HTTP_SERVLET_REQUEST = Endpoint.class.getName() + ".httpServletRequest";
+
     private static final String MCP_CONTEXT_KEY = Endpoint.class.getName() + ".mcpContext";
 
     /**
@@ -421,6 +423,7 @@ public class Endpoint extends CrumbExclusion implements RootAction {
         if (userId != null) {
             contextMap.put(USER_ID, userId);
         }
+        contextMap.put(HTTP_SERVLET_REQUEST, request);
         request.setAttribute(MCP_CONTEXT_KEY, McpTransportContext.create(contextMap));
     }
 }

--- a/src/main/java/io/jenkins/plugins/mcp/server/tool/JenkinsMcpContext.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/tool/JenkinsMcpContext.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.mcp.server.tool;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Data;
+
+@Data
+public class JenkinsMcpContext {
+    private static final ThreadLocal<JenkinsMcpContext> CONTEXT = ThreadLocal.withInitial(JenkinsMcpContext::new);
+
+    HttpServletRequest httpServletRequest;
+
+    /**
+     * Gets the JenkinsMcpContext for the current thread. Creates a new one if it doesn't exist.
+     *
+     * @return The thread-local JenkinsMcpContext instance.
+     */
+    public static JenkinsMcpContext get() {
+        return CONTEXT.get();
+    }
+
+    /**
+     * Clears the JenkinsMcpContext for the current thread to prevent memory leaks.
+     */
+    public static void clear() {
+        CONTEXT.remove();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapper.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapper.java
@@ -26,6 +26,7 @@
 
 package io.jenkins.plugins.mcp.server.tool;
 
+import static io.jenkins.plugins.mcp.server.Endpoint.HTTP_SERVLET_REQUEST;
 import static io.jenkins.plugins.mcp.server.Endpoint.USER_ID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -51,6 +52,7 @@ import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -274,8 +276,12 @@ public class McpToolWrapper {
                     })
                     .toArray();
 
+            var transportContext = exchange.transportContext();
+            var jenkinsMcpContext = JenkinsMcpContext.get();
+            jenkinsMcpContext.setHttpServletRequest((HttpServletRequest) transportContext.get(HTTP_SERVLET_REQUEST));
             var result = method.invoke(target, methodArgs);
             return toMcpResult(result);
+
         } catch (Exception e) {
             var rootCauseMessage = ExceptionUtils.getRootCauseMessage(e);
             if (rootCauseMessage.isEmpty()) {
@@ -295,6 +301,7 @@ public class McpToolWrapper {
                     .build();
         } finally {
             ACL.as(oldUser);
+            JenkinsMcpContext.clear();
         }
     }
 


### PR DESCRIPTION
This introduces a ThreadLocal-based context to pass request-specific data to tool methods without altering their signatures, improving decoupling.
Key changes:
Added JenkinsMcpContext to hold request data via a ThreadLocal.
The context is now set before and cleared after each tool invocation within McpToolWrapper#callRequest.
Refactored DefaultMcpServer to use the context for creating MCPCause.
Use both MCPCause and UserIdCause

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
