### PR TITLE
Return proper 404 for OAuth endpoints instead of Jenkins login redirect

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -153,15 +153,15 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
             handleMessage(request, response, httpServletStreamableServerTransportProvider);
             return true;
         }
-        // Return 404 for OAuth 2.1 endpoints that this plugin doesn't implement.
-        // This tells MCP clients that OAuth DCR is not supported, so they should
+        // Return 404 for OAuth 2.1 /register endpoint.
+        // This tells MCP clients that OAuth is not supported, so they should
         // fall back to using the Authorization header (Basic Auth with API token).
-        if (isOAuthEndpoint(requestedResource)) {
+        if (isOAuthRegisterEndpoint(requestedResource)) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             response.setContentType("application/json");
             response.getWriter()
                     .write(
-                            "{\"error\":\"not_found\",\"error_description\":\"OAuth endpoints not implemented. Use Basic Auth with Jenkins API token.\"}");
+                            "{\"error\":\"not_found\",\"error_description\":\"OAuth /register not supported. Use Basic Auth with Jenkins API token.\"}");
             response.getWriter().flush();
             return true;
         }
@@ -169,13 +169,11 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
     }
 
     /**
-     * Check if the request is for an OAuth 2.1 related endpoint.
+     * Check if the request is for the OAuth 2.1 /register endpoint.
      * Jenkins MCP server uses Basic Auth with API tokens, not OAuth 2.1.
      */
-    private boolean isOAuthEndpoint(String requestedResource) {
-        return requestedResource.equals("/register")
-                || requestedResource.startsWith("/.well-known/oauth")
-                || requestedResource.startsWith("/.well-known/openid");
+    private boolean isOAuthRegisterEndpoint(String requestedResource) {
+        return requestedResource.equals("/register");
     }
 
     protected void init() throws ServletException {

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -159,4 +159,23 @@ public class EndPointTest {
             assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         }
     }
+
+    /**
+     * Tests that OAuth 2.1 /register endpoint returns proper 404 JSON response.
+     * This tells MCP clients that OAuth is not supported, so they should fall back to Basic Auth.
+     */
+    @Test
+    void testOAuthRegisterEndpointReturns404(JenkinsRule jenkins) throws Exception {
+        var url = jenkins.getURL();
+        var registerUrl = url.toString() + "register";
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            var request = new WebRequest(new URL(registerUrl), HttpMethod.POST);
+            var response = webClient.loadWebResponse(request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+            assertThat(response.getContentType()).contains("application/json");
+            assertThat(response.getContentAsString()).contains("not_found");
+            assertThat(response.getContentAsString()).contains("OAuth /register not supported");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

When MCP clients connect using HTTP/SSE transport, they may attempt OAuth 2.1 discovery by hitting `/register` before falling back to header-based authentication. Since this plugin uses Basic Auth with Jenkins API tokens (not OAuth 2.1), these requests currently fall through to Jenkins core, which responds with an HTML login redirect page.

This causes MCP clients to receive unexpected HTML responses, which can be confusing or cause parsing errors.

## The Fix

This PR intercepts OAuth `/register` requests and returns a proper JSON 404 response:

```json
{"error":"not_found","error_description":"OAuth /register not supported. Use Basic Auth with Jenkins API token."}
```

**This is correct behavior per the MCP specification** - when a server doesn't support OAuth, it should return 404 for OAuth discovery endpoints. Compliant MCP clients will then fall back to using the `Authorization` header (Basic Auth with API token).

## Endpoint Handled

- `/register` - OAuth Dynamic Client Registration (RFC 7591)

Note: `/.well-known/*` endpoints are accessed at the server root level (outside Jenkins URL space) and cannot be intercepted by this plugin. The `/register` endpoint is the critical one for OAuth DCR.

## Benefits

1. **Spec-compliant behavior**: Properly signals "OAuth not supported" per MCP spec
2. **Enables fallback**: Compliant MCP clients can now properly fall back to Basic Auth
3. **Cleaner errors**: Returns JSON instead of HTML for non-browser clients
4. **No breaking changes**: Basic Auth with API tokens continues to work as documented

## Testing

- Added `testOAuthRegisterEndpointReturns404` test to verify proper 404 JSON response
- All 122 tests pass

## Note on Claude Code

Claude Code currently has a client-side bug ([#7290](https://github.com/anthropics/claude-code/issues/7290)) where it ignores the `Authorization` header and always attempts OAuth first, without proper fallback. This PR doesn't fix that client bug, but it does provide the correct server-side behavior that compliant MCP clients expect. Users affected by the Claude Code bug can use workarounds like `mcp-remote` until the client is fixed.