### PR TITLE
Exclude heavy properties from MCP responses to reduce context size

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
@@ -40,8 +40,20 @@ import org.kohsuke.stapler.export.TreePruner;
 public class JenkinsExportedBeanSerializer extends JsonSerializer<Object> {
     private static final ModelBuilder MODEL_BUILDER = new ModelBuilder();
 
-    // remove some values which are not useful in the JSON output
-    private static final List<String> EXCLUDED_PROPERTIES = List.of("enclosingBlocks", "nodeId");
+    // Exclude properties that are not useful in LLM context or cause excessive response sizes.
+    // These fall into two categories:
+    // 1. Internal Jenkins machinery (enclosingBlocks, nodeId, actions, properties)
+    // 2. Large collections that can overwhelm LLM context windows (builds, healthReport, queueItem)
+    // Clients needing detailed build info should use getBuild() for specific builds.
+    private static final List<String> EXCLUDED_PROPERTIES = List.of(
+            "enclosingBlocks",
+            "nodeId",
+            "actions",
+            "properties",
+            "builds",
+            "healthReport",
+            "queueItem"
+    );
 
     private static final TreePruner CLEANER_PRUNER = new TreePruner() {
         @Override


### PR DESCRIPTION
This PR expands the property exclusion list in `JenkinsExportedBeanSerializer` to reduce MCP response sizes that can overwhelm LLM context windows.

## Changes

Adds these properties to `EXCLUDED_PROPERTIES`:
- `builds` - full list of all builds (can be huge)
- `actions` - internal Jenkins machinery
- `properties` - job configuration details
- `healthReport` - can be verbose
- `queueItem` - transient state

## Rationale

When using `getJobs` with Claude Code or other LLM clients, the responses were large enough to effectively bust the context window. The excluded properties are either:
1. Internal machinery not useful for LLM reasoning
2. Large collections that should be fetched individually via `getBuild()` when needed

## Testing

The existing tests pass - they verify serialization works, not specific property inclusion.

Fixes #112