### PR TITLE
Add findJobsBySCMUrl tool to lookup jobs by git SCM info

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The plugin provides the following built-in tools for interacting with Jenkins:
 - `getJobScm`: Retrieve SCM configurations of a Jenkins job.
 - `getBuildScm`: Retrieve SCM configurations of a specific build.
 - `getBuildChangeSets`: Retrieve change log sets of a specific build.
+- `findJobsWithScmUrl`: Find jobs using a specific SCM (git) repository URL
 
 #### Management Information
 - `whoAmI`: Get information about the current user.

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/JobScmExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/JobScmExtension.java
@@ -31,19 +31,29 @@ import static io.jenkins.plugins.mcp.server.extensions.util.JenkinsUtil.getBuild
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitStatus;
+import hudson.scm.SCM;
 import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import io.jenkins.plugins.mcp.server.extensions.scm.GitScmUtil;
 import jakarta.annotation.Nullable;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.scm.RunWithSCM;
 import jenkins.triggers.SCMTriggerItem;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
 
 @Extension
 public class JobScmExtension implements McpServerExtension {
+    private static final Logger LOGGER = Logger.getLogger(JobScmExtension.class.getName());
 
     public static boolean isGitPluginInstalled() {
         var gitPlugin = Jenkins.get().getPluginManager().getPlugin("git");
@@ -109,5 +119,135 @@ public class JobScmExtension implements McpServerExtension {
                 .map(RunWithSCM.class::cast)
                 .map(RunWithSCM::getChangeSets)
                 .orElse(List.of());
+    }
+
+    @Tool(
+            description = "Get a paginated list of Jenkins jobs that use the specified git SCM URL",
+            annotations = @Tool.Annotations(destructiveHint = false))
+    public List<Job> findJobsWithScmUrl(
+            @ToolParam(description = "SCM URL to search for (e.g., 'git@github.com:jenkinsci/mcp-server-plugin.git')")
+                    String scmUrl,
+            @ToolParam(description = "SCM Branch (e.g., 'feature/my-feature')", required = false) String branch,
+            @ToolParam(
+                            description = "The 0 based started index, if not specified, then start from the first (0)",
+                            required = false)
+                    Integer skip,
+            @ToolParam(
+                            description =
+                                    "The maximum number of items to return. If not specified, returns 10 items. Cannot exceed 10 items.",
+                            required = false)
+                    Integer limit)
+            throws URISyntaxException {
+
+        if (skip == null || skip < 0) {
+            skip = 0;
+        }
+
+        if (limit == null || limit < 0 || limit > 10) {
+            limit = 10;
+        }
+
+        URIish uri = new URIish(scmUrl);
+
+        List<Job> result = Jenkins.get().getAllItems().stream()
+                .filter(project -> {
+                    SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
+                    if (scmTriggerItem == null) {
+                        return false;
+                    }
+
+                    for (SCM scm : scmTriggerItem.getSCMs()) {
+                        if (scm instanceof GitSCM) {
+                            if (matchesGitSCM(project, (GitSCM) scm, uri, branch)) {
+                                if (LOGGER.isLoggable(Level.FINE)) {
+                                    LOGGER.log(
+                                            Level.FINE,
+                                            "Project: {0} matches SCM URL: {1} and branch: {2}",
+                                            new Object[] {project.getFullDisplayName(), scmUrl, branch});
+                                }
+                                return true;
+                            }
+                        } else {
+                            if (LOGGER.isLoggable(Level.FINER)) {
+                                LOGGER.log(
+                                        Level.FINER,
+                                        "Skipping unhandled SCM type: {0} for project: {1}",
+                                        new Object[] {scm.getType(), project.getFullDisplayName()});
+                            }
+                        }
+                    }
+
+                    return false;
+                })
+                .filter(item -> item instanceof Job)
+                .map(item -> (Job) item)
+                .skip(skip)
+                .limit(limit)
+                .toList();
+
+        return result;
+    }
+
+    private boolean matchesGitSCM(Item project, GitSCM git, URIish uri, String branch) {
+        for (RemoteConfig repository : git.getRepositories()) {
+            boolean repositoryMatches = false;
+            for (URIish remoteURL : repository.getURIs()) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER, "Comparing SCM URL {0} with {1} for {2}", new Object[] {
+                        uri, remoteURL, project.getFullDisplayName()
+                    });
+                }
+                if (GitStatus.looselyMatches(uri, remoteURL)) {
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.log(Level.FINER, "SCM URL {0} matches {1} for {2}", new Object[] {
+                            uri, remoteURL, project.getFullDisplayName()
+                        });
+                    }
+                    repositoryMatches = true;
+                    break;
+                }
+            }
+
+            if (!repositoryMatches) {
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER, "No matching SCM URL found in repository {0} for {1}", new Object[] {
+                        repository.getName(), project.getFullDisplayName()
+                    });
+                }
+                continue;
+            }
+
+            boolean branchFound = false;
+            if (branch == null || branch.isEmpty()) {
+                branchFound = true;
+            } else {
+                for (BranchSpec branchSpec : git.getBranches()) {
+                    // If a parameterized branch spec is used return it as a match
+                    if (branchSpec.getName().contains("$")) {
+                        if (LOGGER.isLoggable(Level.FINE)) {
+                            LOGGER.log(Level.FINE, "Branch Spec is parametrized for {0}", project.getFullDisplayName());
+                        }
+                        branchFound = true;
+                    } else {
+                        if (branchSpec.matchesRepositoryBranch(repository.getName(), branch)) {
+                            if (LOGGER.isLoggable(Level.FINE)) {
+                                LOGGER.log(
+                                        Level.FINE,
+                                        "Branch Spec {0} matches modified branch {1} for {2}",
+                                        new Object[] {branchSpec, branch, project.getFullDisplayName()});
+                            }
+                            branchFound = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (branchFound) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -68,6 +68,7 @@ public class EndPointTest {
                             "getJob",
                             "getJobScm",
                             "getBuildScm",
+                            "findJobsWithScmUrl",
                             "getBuildChangeSets",
                             "getStatus",
                             "getTestResults",


### PR DESCRIPTION
Adds a new tool called `findJobsWithScmUrl` that takes a scm (git) url and an optional branch and paging options and returns jobs that use the git repository.

Implements #111

### Testing done
Verified works with Freestyle jobs
Verified works with standalone Workflow jobs
Verified works with multi-branch pipeline Workflow jobs
Verified works with multi-branch pipeline Workflow jobs with branch specified
Verified works with organization folder jobs (with Bitbucket)
Verified works with organization folder jobs (with Bitbucket) with branch specified

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

