### PR TITLE
feat: Support Extended Choice Parameter in build triggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,12 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>extended-choice-parameter</artifactId>
+      <version>388.ve7b_d0b_920e10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/util/ParameterValueFactoryExtendedChoiceParameterTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/util/ParameterValueFactoryExtendedChoiceParameterTest.java
@@ -1,0 +1,61 @@
+package io.jenkins.plugins.mcp.server.extensions.util;
+
+import static com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition.PARAMETER_TYPE_CHECK_BOX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition;
+import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterValue;
+import hudson.model.ParameterValue;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ParameterValueFactoryExtendedChoiceParameterTest {
+
+    public static Stream<Arguments> extendedChoiceSources() {
+        return Stream.of(Arguments.of("feature, bug"), Arguments.of(List.of("feature", "bug")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("extendedChoiceSources")
+    void createsExtendedChoiceParameterValueUsingCliOverload(Object inputValue) {
+        var param = new ExtendedChoiceParameterDefinition(
+                "test",
+                PARAMETER_TYPE_CHECK_BOX,
+                "feature,bug,fix",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                5,
+                "test",
+                ",");
+        ParameterValue value = ParameterValueFactory.createParameterValue(param, inputValue);
+
+        assertThat(value).isInstanceOfSatisfying(ExtendedChoiceParameterValue.class, v -> assertThat(v.getValue())
+                .isEqualTo("feature,bug"));
+    }
+}


### PR DESCRIPTION
Allows passing single and multi-select Extended Choice parameters when triggering a build by `triggerBuild` mcp call

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
