### PR TITLE
fix: incorrect sse message url

### DIFF
--- a/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsMcpClientBuilder.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsMcpClientBuilder.java
@@ -45,6 +45,7 @@ public interface JenkinsMcpClientBuilder {
         protected JenkinsRule jenkins;
         protected Consumer<HttpRequest.Builder> requestCustomizer;
         protected int requestTimeoutSeconds = 300;
+        protected int initializationTimeoutSeconds = 300;
 
         @Override
         public JenkinsMcpClientBuilder jenkins(JenkinsRule jenkinsRule) {

--- a/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsSSEMcpClientBuilder.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsSSEMcpClientBuilder.java
@@ -51,6 +51,7 @@ public class JenkinsSSEMcpClientBuilder extends JenkinsMcpClientBuilder.Abstract
 
         var client = McpClient.sync(transport)
                 .requestTimeout(Duration.ofSeconds(requestTimeoutSeconds))
+                .initializationTimeout(Duration.ofSeconds(initializationTimeoutSeconds))
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build();
         client.initialize();

--- a/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsStreamableMcpClientBuilder.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/junit/JenkinsStreamableMcpClientBuilder.java
@@ -51,6 +51,7 @@ public class JenkinsStreamableMcpClientBuilder extends JenkinsMcpClientBuilder.A
 
         var client = McpClient.sync(transport)
                 .requestTimeout(Duration.ofSeconds(requestTimeoutSeconds))
+                .initializationTimeout(Duration.ofSeconds(initializationTimeoutSeconds))
                 .capabilities(McpSchema.ClientCapabilities.builder().build())
                 .build();
         client.initialize();


### PR DESCRIPTION
Use a slash leading path as sse message endpoint  when config transport.

Also make the init method lazy to get the correct jenkins full url.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
