### PR TITLE
feat: Return queue item from triggerBuild and add getQueueItem tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,11 @@ The plugin provides the following built-in tools for interacting with Jenkins:
   - **Multi-select Parameters**: Supported as arrays or lists
   - **Custom Plugin Parameters**: Automatically attempted using reflection-based detection
   - **Fallback Behavior**: Unsupported parameters fall back to default values with logging
-#### Build Information
+  This tool returns a queue item if the job is successfully scheduled. You can use the returned queue item ID with the `getQueueItem` tool.
+
+- `getQueueItem`: Get information about a queued item using its ID.
+[
+]()#### Build Information
 - `getBuild`: Retrieve a specific build or the last build of a Jenkins job.
 - `updateBuild`: Update build display name and/or description.
 - `getBuildLog`: Retrieve log lines with pagination for a specific build or the last build.

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -50,6 +50,7 @@ public class EndPointTest {
     void testMcpToolCallSimpleJson(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
 
         try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+
             client.getServerCapabilities();
             var tools = client.listTools();
             assertThat(tools.tools())
@@ -72,7 +73,8 @@ public class EndPointTest {
                             "getBuildChangeSets",
                             "getStatus",
                             "getTestResults",
-                            "getFlakyFailures");
+                            "getFlakyFailures",
+                            "getQueueItem");
 
             var sayHelloTool = tools.tools().stream()
                     .filter(tool -> "sayHello".equals(tool.name()))


### PR DESCRIPTION
The triggerBuild tool now returns the Queue.Item when a build is successfully scheduled. This allows clients to track the build's status right from the queue. A new getQueueItem tool has been added to retrieve details about a specific item in the queue using the ID returned by triggerBuild. The README has also been updated to reflect these changes.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
