### PR TITLE
feat: Support structured output for MCP tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>io.modelcontextprotocol.sdk</groupId>
       <artifactId>mcp-json-jackson2</artifactId>

--- a/src/main/java/io/jenkins/plugins/mcp/server/annotation/Tool.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/annotation/Tool.java
@@ -48,6 +48,11 @@ public @interface Tool {
     String description() default "";
 
     /**
+     * If true, the tool's output will be treated as a structured object and serialized into the `structuredContent` field.
+     */
+    boolean structuredOutput() default false;
+
+    /**
      * To add some _meta content to the tool.
      */
     Meta[] metas() default @Meta;

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -37,6 +37,8 @@ import io.jenkins.plugins.mcp.server.junit.McpClientTest;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
@@ -46,36 +48,39 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 public class EndPointTest {
-    @McpClientTest
-    void testMcpToolCallSimpleJson(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
-
+    void testListTools(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
         try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
-
             client.getServerCapabilities();
             var tools = client.listTools();
-            assertThat(tools.tools())
-                    .extracting(McpSchema.Tool::name)
-                    .containsOnly(
-                            "whoAmI",
-                            "sayHello",
-                            "testInt",
-                            "testWithError",
-                            "getBuildLog",
-                            "searchBuildLog",
-                            "triggerBuild",
-                            "updateBuild",
-                            "getJobs",
-                            "getBuild",
-                            "getJob",
-                            "getJobScm",
-                            "getBuildScm",
-                            "findJobsWithScmUrl",
-                            "getBuildChangeSets",
-                            "getStatus",
-                            "getTestResults",
-                            "getFlakyFailures",
-                            "getQueueItem");
 
+            var expectedFromPlugin = Arrays.asList(
+                    "whoAmI",
+                    "getBuildLog",
+                    "searchBuildLog",
+                    "triggerBuild",
+                    "updateBuild",
+                    "getJobs",
+                    "getBuild",
+                    "getJob",
+                    "getJobScm",
+                    "getBuildScm",
+                    "findJobsWithScmUrl",
+                    "getBuildChangeSets",
+                    "getStatus",
+                    "getTestResults",
+                    "getFlakyFailures",
+                    "getQueueItem");
+            var expected = new ArrayList<>();
+            expected.addAll(expectedFromPlugin);
+            expected.addAll(SampleMcpServer.getAllToolNames());
+            assertThat(tools.tools()).extracting(McpSchema.Tool::name).containsOnly(expected.toArray(new String[] {}));
+        }
+    }
+
+    @McpClientTest
+    void testSampleTool(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            var tools = client.listTools();
             var sayHelloTool = tools.tools().stream()
                     .filter(tool -> "sayHello".equals(tool.name()))
                     .findFirst();

--- a/src/test/java/io/jenkins/plugins/mcp/server/SampleMcpServer.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/SampleMcpServer.java
@@ -29,6 +29,11 @@ package io.jenkins.plugins.mcp.server;
 import hudson.Extension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
+import jakarta.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 @Extension
@@ -59,4 +64,69 @@ public class SampleMcpServer implements McpServerExtension {
     public int testWithError() {
         throw new IllegalArgumentException("Error occurred during execution");
     }
+
+    public static List<String> getAllToolNames() {
+        return Arrays.stream(SampleMcpServer.class.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(Tool.class))
+                .map(Method::getName)
+                .toList();
+    }
+
+    @Tool(structuredOutput = true)
+    public int intWithStructuredOutput() {
+        return 1;
+    }
+
+    @Tool(structuredOutput = true)
+    public Map mapWithStructuredOutput() {
+        return Map.of("key1", "value1");
+    }
+
+    @Tool(structuredOutput = true)
+    public Map mapAsNullWithStructuredOutput() {
+        return null;
+    }
+
+    @Tool(structuredOutput = true)
+    public Collection<String> collectionWithStructuredOutput() {
+        return List.of("item1", "item2");
+    }
+
+    @Tool(structuredOutput = true)
+    public Collection<String> collectionAsNullWithStructuredOutput() {
+        return null;
+    }
+
+    @Tool(structuredOutput = true)
+    public Object genericObjectWithStructuredOutput() {
+        return new CustomObject("John Doe", 30);
+    }
+
+    @Tool(structuredOutput = true)
+    public CustomObject customObjectWithStructuredOutput() {
+        return new CustomObject("John Doe", 30);
+    }
+
+    @Tool(structuredOutput = true)
+    public ParentObject nestedObjectWithStructuredOutput() {
+        return new ParentObject("John Doe", 30, new ChildObject("Child", 20));
+    }
+
+    @Tool(structuredOutput = true)
+    public ParentObject nestedObjectChildNullWithStructuredOutput() {
+        return new ParentObject("John Doe", 30, null);
+    }
+
+    @Tool(structuredOutput = true)
+    public SelfNestedObject selfNestedObjectWithStructuredOutput() {
+        return new SelfNestedObject("item1", new SelfNestedObject("item2", null));
+    }
+
+    public record CustomObject(String name, int age) {}
+
+    public record ChildObject(String name, int age) {}
+
+    public record ParentObject(String name, int age, ChildObject child) {}
+
+    public record SelfNestedObject(String name, @Nullable SelfNestedObject ref) {}
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/StructuredOutputTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/StructuredOutputTest.java
@@ -1,0 +1,198 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server;
+
+import static io.jenkins.plugins.mcp.server.junit.TestUtils.findToolByName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class StructuredOutputTest {
+    @McpClientTest
+    void testIntStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "intWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("intWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isEqualTo(1);
+        }
+    }
+
+    @McpClientTest
+    void testMapStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "mapWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("mapWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isInstanceOfSatisfying(Map.class, value -> assertThat(value)
+                    .containsEntry("key1", "value1"));
+        }
+    }
+
+    @McpClientTest
+    void testMapAsNullStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "mapAsNullWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("mapAsNullWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isNull();
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testCollectionWithStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "collectionWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("collectionWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isInstanceOfSatisfying(List.class, value -> assertThat(value)
+                    .contains("item1", "item2"));
+        }
+    }
+
+    @McpClientTest
+    void testCollectionAsNullWithStructuredOutput(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "collectionAsNullWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("collectionAsNullWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isNull();
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testGenericObjectWithStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "genericObjectWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("genericObjectWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isInstanceOfSatisfying(Map.class, value -> assertThat(value)
+                    .containsEntry("name", "John Doe")
+                    .containsEntry("age", 30));
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testCustomObjectWithStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "customObjectWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("customObjectWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            assertThat(response.structuredContent()).isInstanceOfSatisfying(Map.class, value -> assertThat(value)
+                    .containsEntry("name", "John Doe")
+                    .containsEntry("age", 30));
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testNestedObjectWithStructuredOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "nestedObjectWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("nestedObjectWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            Map<String, Object> nestedObject = (Map<String, Object>) response.structuredContent();
+            var childObject = (Map<String, Object>) nestedObject.get("child");
+            assertThat(childObject).containsEntry("name", "Child").containsEntry("age", 20);
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testNestedObjectChildNullWithStructuredOutput(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "nestedObjectChildNullWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("nestedObjectChildNullWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            Map<String, Object> nestedObject = (Map<String, Object>) response.structuredContent();
+            assertThat(nestedObject).containsEntry("child", null);
+        }
+    }
+
+    @McpClientTest
+    @SuppressWarnings("unchecked")
+    void testSelfNestedObjectWithStructuredOutput(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            client.getServerCapabilities();
+            var tool = findToolByName(client.listTools(), "selfNestedObjectWithStructuredOutput");
+            assertThat(tool.outputSchema()).isNotNull();
+
+            McpSchema.CallToolRequest request =
+                    new McpSchema.CallToolRequest("selfNestedObjectWithStructuredOutput", Map.of());
+            var response = client.callTool(request);
+            Map<String, Object> nestedObject = (Map<String, Object>) response.structuredContent();
+            var childObject = (Map<String, Object>) nestedObject.get("ref");
+            assertThat(childObject).containsEntry("name", "item2").containsEntry("ref", null);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/junit/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/junit/TestUtils.java
@@ -26,6 +26,7 @@
 
 package io.jenkins.plugins.mcp.server.junit;
 
+import io.modelcontextprotocol.spec.McpSchema;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
@@ -41,5 +42,12 @@ public class TestUtils {
         Object[] combined = Arrays.copyOf(original, original.length + 1);
         combined[original.length] = extra;
         return combined;
+    }
+
+    public static McpSchema.Tool findToolByName(McpSchema.ListToolsResult listToolsResult, String name) {
+        return listToolsResult.tools().stream()
+                .filter(tool -> name.equals(tool.name()))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapperTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapperTest.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.tool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jenkins.plugins.mcp.server.annotation.Tool;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+class McpToolWrapperTest {
+    MockMethods target = new MockMethods();
+    ObjectMapper objectMapper = new ObjectMapper();
+    ;
+
+    @Test
+    void generateForOutputOfBoolean() throws NoSuchMethodException {
+
+        McpToolWrapper wrapper =
+                new McpToolWrapper(objectMapper, target, MockMethods.class.getDeclaredMethod("boolMethod"));
+        var output = wrapper.generateForOutput();
+        System.out.println(output);
+    }
+
+    @Test
+    void generateForOutputOfMap() throws NoSuchMethodException {
+
+        McpToolWrapper wrapper =
+                new McpToolWrapper(objectMapper, target, MockMethods.class.getDeclaredMethod("mapMethod"));
+        var output = wrapper.generateForOutput();
+        System.out.println(output);
+    }
+
+    @Test
+    void generateForOutputOfComplex() throws NoSuchMethodException {
+
+        McpToolWrapper wrapper =
+                new McpToolWrapper(objectMapper, target, MockMethods.class.getDeclaredMethod("complexMethod"));
+        var output = wrapper.generateForOutput();
+        System.out.println(output);
+    }
+
+    public static class MockMethods {
+        @Tool
+        public boolean boolMethod() {
+            return false;
+        }
+
+        @Tool
+        public Map<String, String> mapMethod() {
+            return Map.of("result", "ok");
+        }
+
+        @Tool
+        public ComplexType complexMethod() {
+            return new ComplexType(true, Map.of("result", "ok"), 200);
+        }
+
+        @Tool
+        public ComplexTypeClass complexMethodA() {
+            return new ComplexTypeClass(true, Map.of("result", "ok"), 200);
+        }
+
+        public record ComplexType(boolean success, Map<String, Object> data, int code) {}
+
+        @Data
+        @AllArgsConstructor
+        public static class ComplexTypeClass {
+            boolean success;
+            Map<String, Object> data;
+            int code;
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a `structuredOutput` property to the `@Tool` annotation.

When `structuredOutput` is set to `true`, the return value of a tool method will be serialized as a structured object and placed in the `structuredContent` field of the MCP response.

For backward compatibility, the `content` field is always populated with a string representation of the output, regardless of the `structuredOutput` setting. This ensures that older clients can still process the response.

This feature enables tools to return complex data types like Maps, Lists, or custom POJOs, which can be directly consumed by modern clients without needing to parse a string.

Added `StructuredOutputTest` to verify the functionality with various data types, including primitives, collections, maps, and nested objects.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
