### PR TITLE
feat: Support tree pruner filter

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/annotation/Tool.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/annotation/Tool.java
@@ -53,6 +53,11 @@ public @interface Tool {
     boolean structuredOutput() default false;
 
     /**
+     * If true, the tool's output will be filtered follow Jenkins rest api tree pruning feature.
+     * Any elements marked with @ExportedBean support tree pruning automatically.
+     */
+    boolean treePruneSupported() default false;
+    /**
      * To add some _meta content to the tool.
      */
     Meta[] metas() default @Meta;

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -27,6 +27,7 @@
 package io.jenkins.plugins.mcp.server.extensions;
 
 import static io.jenkins.plugins.mcp.server.extensions.DefaultMcpServer.FULL_NAME;
+import static io.jenkins.plugins.mcp.server.junit.TestUtils.MIN_1;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -59,7 +60,6 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class DefaultMcpServerTest {
-    static final int MIN_1 = 60 * 1000;
 
     public static Stream<Arguments> whoAmITestParameters() {
         Stream<Arguments> baseArgs = Stream.of(Arguments.of(true, "admin"), Arguments.of(false, "anonymous"));

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/TreePruneMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/TreePruneMcpServerTest.java
@@ -1,0 +1,122 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static io.jenkins.plugins.mcp.server.junit.TestUtils.MIN_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class TreePruneMcpServerTest {
+
+    @McpClientTest
+    void testMcpToolCallGetBuildWithTreePrune(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
+        project.setDefinition(new CpsFlowDefinition("", true));
+        var build = project.scheduleBuild2(0).get();
+
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuild", Map.of("jobFullName", project.getFullName(), "tree", "number"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+            assertThat(response.content()).first().isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                assertThat(textContent.type()).isEqualTo("text");
+                DocumentContext documentContext =
+                        JsonPath.using(Configuration.defaultConfiguration()).parse(textContent.text());
+                var contentMap = documentContext.read("$.result", Map.class);
+                assertThat(contentMap).hasSize(2).extractingByKey("number").isEqualTo(build.getNumber());
+            });
+        }
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "getBuild", Map.of("jobFullName", project.getFullName(), "tree", "number,result"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+            assertThat(response.content()).first().isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                assertThat(textContent.type()).isEqualTo("text");
+                DocumentContext documentContext =
+                        JsonPath.using(Configuration.defaultConfiguration()).parse(textContent.text());
+                var contentMap = documentContext.read("$.result", Map.class);
+                assertThat(contentMap).hasSize(3).extractingByKey("number").isEqualTo(build.getNumber());
+            });
+        }
+    }
+
+    @McpClientTest
+    void testMcpToolCallGetJobsWithAuth(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        for (int i = 0; i < 2; i++) {
+            jenkins.createProject(WorkflowJob.class, "demo-job" + i);
+        }
+
+        var folder = jenkins.createFolder("test");
+
+        for (int i = 0; i < 20; i++) {
+            folder.createProject(WorkflowJob.class, "sub-demo-job" + i);
+        }
+
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            {
+                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                        "getJobs", Map.of("parentFullName", "test", "limit", 10, "tree", "name"));
+
+                var response = client.callTool(request);
+                assertThat(response.isError()).isFalse();
+                assertThat(response.content().get(0).type()).isEqualTo("text");
+                DocumentContext documentContext = JsonPath.using(Configuration.defaultConfiguration())
+                        .parse(((McpSchema.TextContent) response.content().get(0)).text());
+                var contentList = documentContext.read("$.result", List.class);
+                assertThat(contentList).hasSize(10);
+                assertThat(contentList.get(0)).isInstanceOfSatisfying(Map.class, contentMap -> {
+                    // var contentMap = objectMapper.readValue(textContent.text(), Map.class);
+                    assertThat(contentMap).hasSize(2).containsEntry("name", "sub-demo-job0");
+                });
+            }
+        }
+        jenkins.waitUntilNoActivityUpTo(MIN_1);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/junit/TestUtils.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/junit/TestUtils.java
@@ -32,6 +32,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class TestUtils {
+
+    public static final int MIN_1 = 60 * 1000;
+
     public static Stream<Arguments> appendMcpClientArgs(Stream<Arguments> baseArgs) {
         return baseArgs.flatMap(args -> Stream.of(
                 Arguments.of(append(args.get(), new JenkinsSSEMcpClientBuilder())),


### PR DESCRIPTION
The bean serialized by Jenkins' `JSON.Flavor` now supports a "tree" argument. This follows the behavior of the `tree` parameter in the Jenkins REST API, allowing for filtering of the serialized output.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
