### PR TITLE
Gratuitous use of `User` when `Authentication` would suffice

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -32,7 +32,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.PluginWrapper;
 import hudson.model.RootAction;
-import hudson.model.User;
 import hudson.security.csrf.CrumbExclusion;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.tool.McpToolWrapper;
@@ -117,7 +116,7 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
     public static final String METRICS_ENDPOINT = "/metrics";
 
     public static final String MCP_SERVER_METRICS = MCP_SERVER + METRICS_ENDPOINT;
-    public static final String USER_ID = Endpoint.class.getName() + ".userId";
+    public static final String AUTHENTICATION = Endpoint.class.getName() + ".authentication";
     public static final String HTTP_SERVLET_REQUEST = Endpoint.class.getName() + ".httpServletRequest";
 
     private static final String MCP_CONTEXT_KEY = Endpoint.class.getName() + ".mcpContext";
@@ -810,14 +809,7 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
 
     private static void prepareMcpContext(HttpServletRequest request) {
         Map<String, Object> contextMap = new HashMap<>();
-        var currentUser = User.current();
-        String userId = null;
-        if (currentUser != null) {
-            userId = currentUser.getId();
-        }
-        if (userId != null) {
-            contextMap.put(USER_ID, userId);
-        }
+        contextMap.put(AUTHENTICATION, Jenkins.getAuthentication2());
         contextMap.put(HTTP_SERVLET_REQUEST, request);
         request.setAttribute(MCP_CONTEXT_KEY, McpTransportContext.create(contextMap));
     }

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.model.queue.QueueItem;
@@ -239,14 +238,14 @@ public class DefaultMcpServer implements McpServerExtension {
 
     @Tool(
             description =
-                    "Get information about the currently authenticated user, including their full name or 'anonymous' if not authenticated",
+                    "Get information about the currently authenticated user/principal, including their full name or 'anonymous' if not authenticated",
             structuredOutput = true,
             annotations = @Tool.Annotations(destructiveHint = false))
     @SneakyThrows
     public WhoAmIResponse whoAmI() {
-        return Optional.ofNullable(User.current())
-                .map(user -> new WhoAmIResponse(user.getFullName()))
-                .orElse(new WhoAmIResponse("anonymous"));
+        var name = Jenkins.getAuthentication2().getName();
+        var user = User.getById(name, false);
+        return new WhoAmIResponse(user != null ? user.getFullName() : name);
     }
 
     @Tool(

--- a/src/main/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapper.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/tool/McpToolWrapper.java
@@ -26,8 +26,8 @@
 
 package io.jenkins.plugins.mcp.server.tool;
 
+import static io.jenkins.plugins.mcp.server.Endpoint.AUTHENTICATION;
 import static io.jenkins.plugins.mcp.server.Endpoint.HTTP_SERVLET_REQUEST;
-import static io.jenkins.plugins.mcp.server.Endpoint.USER_ID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -42,7 +42,6 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.module.jackson.JacksonModule;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
-import hudson.model.User;
 import hudson.security.ACL;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
@@ -73,6 +72,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -305,8 +305,8 @@ public class McpToolWrapper {
     }
 
     private McpSchema.CallToolResult call(McpTransportContext mcpTransportContext, McpSchema.CallToolRequest request) {
-        var user = tryGetUser(mcpTransportContext);
-        try (var ignored = switchTo(user);
+        var authn = tryGetAuthentication(mcpTransportContext);
+        try (var ignored = switchTo(authn);
                 var jenkinsMcpContext = JenkinsMcpContext.get()) {
             // need Jenkins.READ at least
             Jenkins.get().checkPermission(Jenkins.READ);
@@ -357,17 +357,13 @@ public class McpToolWrapper {
         }
     }
 
-    private static User tryGetUser(McpTransportContext context) {
-        String userId = null;
-        if (context != null) {
-            userId = (String) context.get(USER_ID);
-        }
-        return User.get(userId, false, Map.of());
+    private static Authentication tryGetAuthentication(McpTransportContext context) {
+        return context != null ? (Authentication) context.get(AUTHENTICATION) : null;
     }
 
-    private static AutoCloseable switchTo(User user) {
-        if (user != null) {
-            return ACL.as(user);
+    private static AutoCloseable switchTo(Authentication authn) {
+        if (authn != null) {
+            return ACL.as2(authn);
         } else {
             return () -> {
                 /* nothing to do */


### PR DESCRIPTION
Untested, but I think the current code would not work with [CloudBees CI service accounts](https://docs.cloudbees.com/docs/cloudbees-ci/latest/secure/service-accounts) or generally any system based directly on Spring Security that does not necessarily correspond to a Jenkins `User`, such as https://github.com/jenkinsci/jenkins/pull/26686 as I understand it. See also #171. I presume the values in this `contextMap` need not be `Serializable`, since we already storing a `HttpServletRequest`? CC @olamy