### PR TITLE
Add user breakdown to MCP metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,25 @@ This endpoint requires authentication (standard Jenkins permissions) and provide
   "streamableRequestsTotal": 150,
   "connectionErrorsTotal": 2,
   "uptimeSeconds": 3600,
-  "startTime": "2025-01-28T10:00:00Z"
+  "startTime": "2025-01-28T10:00:00Z",
+  "users": {
+    "alice": {
+      "sseConnectionsTotal": 10,
+      "sseConnectionsActive": 1,
+      "streamableRequestsTotal": 50,
+      "connectionErrorsTotal": 0
+    },
+    "bob": {
+      "sseConnectionsTotal": 32,
+      "sseConnectionsActive": 2,
+      "streamableRequestsTotal": 100,
+      "connectionErrorsTotal": 2
+    }
+  }
 }
 ```
+
+The top-level counters are server-wide aggregates. The `users` object breaks down the same counters per Jenkins user (including `anonymous` and `SYSTEM`), allowing you to see which accounts are actively connected and how much traffic each is generating.
 
 #### Graceful Shutdown
 

--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -277,7 +277,7 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
                 response.sendError(HttpServletResponse.SC_NOT_FOUND, "Streamable endpoint is disabled");
                 return true;
             }
-            McpConnectionMetrics.recordStreamableRequest();
+            McpConnectionMetrics.recordStreamableRequest(Jenkins.getAuthentication2().getName());
             handleMessage(request, response, httpServletStreamableServerTransportProvider);
             return true;
         }
@@ -537,7 +537,7 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
             if (isBrowserRequest(req)) {
                 serveBrowserPage(resp);
             } else {
-                McpConnectionMetrics.recordStreamableRequest();
+                McpConnectionMetrics.recordStreamableRequest(Jenkins.getAuthentication2().getName());
                 handleMessage(req, resp, httpServletStreamableServerTransportProvider);
             }
             return true;
@@ -718,16 +718,17 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
     private void handleSSE(HttpServletRequest request, HttpServletResponse response)
             throws IOException, ServletException {
         String clientInfo = getClientInfo(request);
+        String username = Jenkins.getAuthentication2().getName();
         log.info("SSE connection started from {}", clientInfo);
-        McpConnectionMetrics.recordSseConnectionStart();
+        McpConnectionMetrics.recordSseConnectionStart(username);
         try {
             httpServletSseServerTransportProvider.service(request, response);
         } catch (IOException e) {
             log.warn("SSE connection error from {}: {}", clientInfo, e.getMessage());
-            McpConnectionMetrics.recordConnectionError();
+            McpConnectionMetrics.recordConnectionError(username);
             throw e;
         } finally {
-            McpConnectionMetrics.recordSseConnectionEnd();
+            McpConnectionMetrics.recordSseConnectionEnd(username);
             log.info("SSE connection ended from {}", clientInfo);
         }
     }

--- a/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/Endpoint.java
@@ -277,7 +277,8 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
                 response.sendError(HttpServletResponse.SC_NOT_FOUND, "Streamable endpoint is disabled");
                 return true;
             }
-            McpConnectionMetrics.recordStreamableRequest(Jenkins.getAuthentication2().getName());
+            McpConnectionMetrics.recordStreamableRequest(
+                    Jenkins.getAuthentication2().getName());
             handleMessage(request, response, httpServletStreamableServerTransportProvider);
             return true;
         }
@@ -537,7 +538,8 @@ public class Endpoint extends CrumbExclusion implements RootAction, HttpServletF
             if (isBrowserRequest(req)) {
                 serveBrowserPage(resp);
             } else {
-                McpConnectionMetrics.recordStreamableRequest(Jenkins.getAuthentication2().getName());
+                McpConnectionMetrics.recordStreamableRequest(
+                        Jenkins.getAuthentication2().getName());
                 handleMessage(req, resp, httpServletStreamableServerTransportProvider);
             }
             return true;

--- a/src/main/java/io/jenkins/plugins/mcp/server/McpConnectionMetrics.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/McpConnectionMetrics.java
@@ -32,6 +32,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import jenkins.model.Jenkins;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +56,15 @@ import org.springframework.security.access.AccessDeniedException;
  *   "streamableRequestsTotal": 150,
  *   "connectionErrorsTotal": 2,
  *   "uptimeSeconds": 3600,
- *   "startTime": "2025-01-28T10:00:00Z"
+ *   "startTime": "2025-01-28T10:00:00Z",
+ *   "users": {
+ *     "alice": {
+ *       "sseConnectionsTotal": 10,
+ *       "sseConnectionsActive": 1,
+ *       "streamableRequestsTotal": 50,
+ *       "connectionErrorsTotal": 0
+ *     }
+ *   }
  * }
  * </pre>
  */
@@ -93,6 +102,22 @@ public class McpConnectionMetrics {
     private static final Instant startTime = Instant.now();
 
     /**
+     * Per-user metrics, keyed by Jenkins username (including "anonymous" and "SYSTEM").
+     */
+    static final ConcurrentHashMap<String, UserMetrics> userMetrics = new ConcurrentHashMap<>();
+
+    private static UserMetrics userMetricsFor(String username) {
+        return userMetrics.computeIfAbsent(username, k -> new UserMetrics());
+    }
+
+    static final class UserMetrics {
+        final AtomicLong sseConnectionsTotal = new AtomicLong(0);
+        final AtomicLong sseConnectionsActive = new AtomicLong(0);
+        final AtomicLong streamableRequestsTotal = new AtomicLong(0);
+        final AtomicLong connectionErrorsTotal = new AtomicLong(0);
+    }
+
+    /**
      * Handles GET requests to the metrics endpoint.
      * Requires authentication (checks Jenkins.READ permission).
      * This method is called directly from the HttpServletFilter.
@@ -128,6 +153,17 @@ public class McpConnectionMetrics {
         responseJson.put("uptimeSeconds", uptime.getSeconds());
         responseJson.put("startTime", startTime.toString());
 
+        ObjectNode usersNode = objectMapper.createObjectNode();
+        userMetrics.forEach((username, metrics) -> {
+            ObjectNode userNode = objectMapper.createObjectNode();
+            userNode.put("sseConnectionsTotal", metrics.sseConnectionsTotal.get());
+            userNode.put("sseConnectionsActive", metrics.sseConnectionsActive.get());
+            userNode.put("streamableRequestsTotal", metrics.streamableRequestsTotal.get());
+            userNode.put("connectionErrorsTotal", metrics.connectionErrorsTotal.get());
+            usersNode.set(username, userNode);
+        });
+        responseJson.set("users", usersNode);
+
         response.getWriter().write(objectMapper.writeValueAsString(responseJson));
         response.getWriter().flush();
     }
@@ -141,10 +177,28 @@ public class McpConnectionMetrics {
     }
 
     /**
+     * Records a new SSE connection starting for the given user.
+     */
+    public static void recordSseConnectionStart(String username) {
+        recordSseConnectionStart();
+        UserMetrics u = userMetricsFor(username);
+        u.sseConnectionsTotal.incrementAndGet();
+        u.sseConnectionsActive.incrementAndGet();
+    }
+
+    /**
      * Records an SSE connection ending.
      */
     public static void recordSseConnectionEnd() {
         sseConnectionsActive.decrementAndGet();
+    }
+
+    /**
+     * Records an SSE connection ending for the given user.
+     */
+    public static void recordSseConnectionEnd(String username) {
+        recordSseConnectionEnd();
+        userMetricsFor(username).sseConnectionsActive.decrementAndGet();
     }
 
     /**
@@ -155,10 +209,26 @@ public class McpConnectionMetrics {
     }
 
     /**
+     * Records a Streamable HTTP request for the given user.
+     */
+    public static void recordStreamableRequest(String username) {
+        recordStreamableRequest();
+        userMetricsFor(username).streamableRequestsTotal.incrementAndGet();
+    }
+
+    /**
      * Records a connection error.
      */
     public static void recordConnectionError() {
         connectionErrorsTotal.incrementAndGet();
+    }
+
+    /**
+     * Records a connection error for the given user.
+     */
+    public static void recordConnectionError(String username) {
+        recordConnectionError();
+        userMetricsFor(username).connectionErrorsTotal.incrementAndGet();
     }
 
     /**
@@ -205,5 +275,6 @@ public class McpConnectionMetrics {
         sseConnectionsActive.set(0);
         streamableRequestsTotal.set(0);
         connectionErrorsTotal.set(0);
+        userMetrics.clear();
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/McpConnectionMetricsTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/McpConnectionMetricsTest.java
@@ -164,4 +164,101 @@ class McpConnectionMetricsTest {
         assertThat(McpConnectionMetrics.getTotalStreamableRequests()).isZero();
         assertThat(McpConnectionMetrics.getTotalConnectionErrors()).isZero();
     }
+
+    @Test
+    void testPerUserSseConnectionMetrics() {
+        McpConnectionMetrics.recordSseConnectionStart("alice");
+        McpConnectionMetrics.recordSseConnectionStart("alice");
+        McpConnectionMetrics.recordSseConnectionStart("bob");
+
+        McpConnectionMetrics.UserMetrics alice = McpConnectionMetrics.userMetrics.get("alice");
+        McpConnectionMetrics.UserMetrics bob = McpConnectionMetrics.userMetrics.get("bob");
+
+        assertThat(alice).isNotNull();
+        assertThat(alice.sseConnectionsTotal.get()).isEqualTo(2);
+        assertThat(alice.sseConnectionsActive.get()).isEqualTo(2);
+
+        assertThat(bob).isNotNull();
+        assertThat(bob.sseConnectionsTotal.get()).isOne();
+        assertThat(bob.sseConnectionsActive.get()).isOne();
+
+        // Global counters should also reflect the combined total
+        assertThat(McpConnectionMetrics.getTotalSseConnections()).isEqualTo(3);
+        assertThat(McpConnectionMetrics.getActiveSseConnections()).isEqualTo(3);
+
+        McpConnectionMetrics.recordSseConnectionEnd("alice");
+        assertThat(alice.sseConnectionsActive.get()).isOne();
+        assertThat(McpConnectionMetrics.getActiveSseConnections()).isEqualTo(2);
+    }
+
+    @Test
+    void testPerUserStreamableRequestMetrics() {
+        McpConnectionMetrics.recordStreamableRequest("carol");
+        McpConnectionMetrics.recordStreamableRequest("carol");
+        McpConnectionMetrics.recordStreamableRequest("dave");
+
+        McpConnectionMetrics.UserMetrics carol = McpConnectionMetrics.userMetrics.get("carol");
+        McpConnectionMetrics.UserMetrics dave = McpConnectionMetrics.userMetrics.get("dave");
+
+        assertThat(carol).isNotNull();
+        assertThat(carol.streamableRequestsTotal.get()).isEqualTo(2);
+
+        assertThat(dave).isNotNull();
+        assertThat(dave.streamableRequestsTotal.get()).isOne();
+
+        assertThat(McpConnectionMetrics.getTotalStreamableRequests()).isEqualTo(3);
+    }
+
+    @Test
+    void testPerUserConnectionErrorMetrics() {
+        McpConnectionMetrics.recordConnectionError("alice");
+        McpConnectionMetrics.recordConnectionError("alice");
+        McpConnectionMetrics.recordConnectionError("bob");
+
+        McpConnectionMetrics.UserMetrics alice = McpConnectionMetrics.userMetrics.get("alice");
+        McpConnectionMetrics.UserMetrics bob = McpConnectionMetrics.userMetrics.get("bob");
+
+        assertThat(alice).isNotNull();
+        assertThat(alice.connectionErrorsTotal.get()).isEqualTo(2);
+
+        assertThat(bob).isNotNull();
+        assertThat(bob.connectionErrorsTotal.get()).isOne();
+
+        assertThat(McpConnectionMetrics.getTotalConnectionErrors()).isEqualTo(3);
+    }
+
+    @Test
+    void testResetClearsUserMetrics() {
+        McpConnectionMetrics.recordSseConnectionStart("alice");
+        McpConnectionMetrics.recordStreamableRequest("bob");
+
+        assertThat(McpConnectionMetrics.userMetrics).isNotEmpty();
+
+        McpConnectionMetrics.reset();
+
+        assertThat(McpConnectionMetrics.userMetrics).isEmpty();
+    }
+
+    @Test
+    void testMetricsEndpointIncludesUsersSection(JenkinsRule jenkins) throws Exception {
+        McpConnectionMetrics.recordSseConnectionStart("alice");
+        McpConnectionMetrics.recordStreamableRequest("alice");
+        McpConnectionMetrics.recordStreamableRequest("bob");
+
+        try (JenkinsRule.WebClient webClient = jenkins.createWebClient()) {
+            var metricsUrl = jenkins.getURL().toString() + McpConnectionMetrics.URL_NAME;
+            var request = new WebRequest(new URL(metricsUrl), HttpMethod.GET);
+            WebResponse response = webClient.loadWebResponse(request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+
+            DocumentContext json = JsonPath.parse(response.getContentAsString());
+            assertThat(json.read("$.users", Object.class)).isNotNull();
+            assertThat(json.read("$.users.alice.sseConnectionsTotal", Long.class)).isEqualTo(1L);
+            assertThat(json.read("$.users.alice.sseConnectionsActive", Long.class)).isEqualTo(1L);
+            assertThat(json.read("$.users.alice.streamableRequestsTotal", Long.class)).isEqualTo(1L);
+            assertThat(json.read("$.users.alice.connectionErrorsTotal", Long.class)).isZero();
+            assertThat(json.read("$.users.bob.streamableRequestsTotal", Long.class)).isEqualTo(1L);
+        }
+    }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/McpConnectionMetricsTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/McpConnectionMetricsTest.java
@@ -254,11 +254,16 @@ class McpConnectionMetricsTest {
 
             DocumentContext json = JsonPath.parse(response.getContentAsString());
             assertThat(json.read("$.users", Object.class)).isNotNull();
-            assertThat(json.read("$.users.alice.sseConnectionsTotal", Long.class)).isEqualTo(1L);
-            assertThat(json.read("$.users.alice.sseConnectionsActive", Long.class)).isEqualTo(1L);
-            assertThat(json.read("$.users.alice.streamableRequestsTotal", Long.class)).isEqualTo(1L);
-            assertThat(json.read("$.users.alice.connectionErrorsTotal", Long.class)).isZero();
-            assertThat(json.read("$.users.bob.streamableRequestsTotal", Long.class)).isEqualTo(1L);
+            assertThat(json.read("$.users.alice.sseConnectionsTotal", Long.class))
+                    .isEqualTo(1L);
+            assertThat(json.read("$.users.alice.sseConnectionsActive", Long.class))
+                    .isEqualTo(1L);
+            assertThat(json.read("$.users.alice.streamableRequestsTotal", Long.class))
+                    .isEqualTo(1L);
+            assertThat(json.read("$.users.alice.connectionErrorsTotal", Long.class))
+                    .isZero();
+            assertThat(json.read("$.users.bob.streamableRequestsTotal", Long.class))
+                    .isEqualTo(1L);
         }
     }
 }


### PR DESCRIPTION
### Summary
The /mcp-server/metrics endpoint previously only reported server wide aggregate counters. This change extends it to include a per-user breakdown, making it easier to identify which Jenkins accounts are actively connected and how much traffic each one is generating.

### Changelist
* Added `UserMetrics` inner class to `McpConnectionMetrics` tracking per-user SSE connections (total and active), streamable requests, and connection errors
* Added overloaded recording methods (recordSseConnectionStart, recordSseConnectionEnd, recordStreamableRequest, recordConnectionError) that accept a username and update both global and per-user counters atomically
* Updated `Endpoint.java` to pass `Jenkins.getAuthentication2().getName()` at all three metric recording call sites (SSE lifecycle and both streamable request paths)
* Metrics JSON response now includes a users object keyed by Jenkins username; all users are tracked including anonymous and SYSTEM
* Updated `reset()` to clear per-user metrics alongside global counters
* Added unit tests covering per-user SSE, streamable, error tracking, reset behavior, and the live endpoint JSON shape
* Updated `README` metrics section with the new response shape and a note on the per-user breakdown

### Testing done
Ran unit tests in vscode:
```

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.61 s -- in io.jenkins.plugins.mcp.server.McpConnectionMetricsTest

Results:

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0

------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  56.396 s
Finished at: 2026-05-09T16:22:14-04:00
------------------------------------------------------------------------
```
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
