### PR TITLE
Modify Claude command for jenkins addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Streamable example:
 
 #### Claude
 ```bash
-claude mcp add jenkins http://jenkins-host/mcp-server/mcp --transport http --header "Authorization: Basic <user:token base64>"
+claude mcp add -s user jenkins https://jenkins-host/mcp-server/mcp --transport http --header "Authorization: Basic <user:token base64>"
 ```
 
 #### Stateless Configuration Example


### PR DESCRIPTION
Without `-s user`, the server gets activated only for the current directory, which is probably not what you want, at least if you work with several different jobs building different repositories. Context: https://github.com/jenkins-infra/helpdesk/issues/5140#issuecomment-4633560331

Also adjusting the example to use `https` scheme, which I would hope would be the case for any production system.