### PR TITLE
Correct MCP tool hinting for Jenkins server tools

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
@@ -58,7 +58,7 @@ public class BuildLogsExtension implements McpServerExtension {
             description =
                     "Retrieves some log lines with pagination for a specific build or the last build of a Jenkins job,"
                             + " as well as a boolean value indicating whether there is more content to retrieve",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public BuildLogResponse getBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(
@@ -100,7 +100,7 @@ public class BuildLogsExtension implements McpServerExtension {
             description =
                     "Search for log lines matching a pattern in a specific build or the last build of a Jenkins job. "
                             + "Returns matching lines with their line numbers and context.",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public SearchLogResponse searchBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -75,7 +75,7 @@ public class DefaultMcpServer implements McpServerExtension {
 
     @Tool(
             description = "Get a specific build or the last build of a Jenkins job",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public Run getBuild(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -86,7 +86,9 @@ public class DefaultMcpServer implements McpServerExtension {
         return getBuildByNumberOrLast(jobFullName, buildNumber).orElse(null);
     }
 
-    @Tool(description = "Get a Jenkins job by its full path", annotations = @Tool.Annotations(destructiveHint = false))
+    @Tool(
+            description = "Get a Jenkins job by its full path",
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public Job getJob(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName) {
         return Jenkins.get().getItemByFullName(jobFullName, Job.class);
@@ -118,8 +120,10 @@ public class DefaultMcpServer implements McpServerExtension {
         }
     }
 
-    @Tool(description = "Trigger a build for a Jenkins job", treePruneSupported = true)
-    // keep the default value for destructive (true)
+    @Tool(
+            description = "Trigger a build for a Jenkins job",
+            treePruneSupported = true,
+            annotations = @Tool.Annotations(destructiveHint = false))
     public QueueItem triggerBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "Build parameters (optional, e.g., {key1=value1,key2=value2})", required = false)
@@ -160,7 +164,7 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description =
                     "Get a paginated list of Jenkins jobs, sorted by name. Returns up to 'limit' jobs starting from the 'skip' index. If no jobs are available in the requested range, returns an empty list.",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public List<Job> getJobs(
             @ToolParam(
                             description =
@@ -240,7 +244,7 @@ public class DefaultMcpServer implements McpServerExtension {
             description =
                     "Get information about the currently authenticated user/principal, including their full name or 'anonymous' if not authenticated",
             structuredOutput = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     @SneakyThrows
     public WhoAmIResponse whoAmI() {
         var name = Jenkins.getAuthentication2().getName();
@@ -255,7 +259,7 @@ public class DefaultMcpServer implements McpServerExtension {
                             + " This tool provides a comprehensive overview of the controller's operational state to determine if"
                             + " it's stable and ready to build. Use this tool to assess Jenkins instance health rather than"
                             + " simple up/down status.",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public Map<String, Object> getStatus() {
         var map = new HashMap<String, Object>();
         var jenkins = Jenkins.get();
@@ -306,7 +310,7 @@ public class DefaultMcpServer implements McpServerExtension {
             description =
                     "Get the queue item details by its ID. The caller can check the queue item's status, build details, and other relevant information.",
             treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public QueueItem getQueueItem(@ToolParam(description = "The queue item id") long id) {
         return Jenkins.get().getQueue().getItem(id);
     }
@@ -314,7 +318,8 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description =
                     "Rebuild a Jenkins build: re-run with the same parameters (and for Pipeline jobs, the same script when possible). Returns the queue item for the new build.",
-            treePruneSupported = true)
+            treePruneSupported = true,
+            annotations = @Tool.Annotations(destructiveHint = false))
     public QueueItem rebuildBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -356,7 +361,7 @@ public class DefaultMcpServer implements McpServerExtension {
             description =
                     "Get the pipeline script(s) of a build for replay. Returns the main script and loaded scripts. Only available for Pipeline (replayable) builds.",
             structuredOutput = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public GetReplayScriptsResult getReplayScripts(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -382,7 +387,8 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description =
                     "Replay a Pipeline build with optionally modified script(s). Runs the job again with the given main script and optional loaded scripts. Only available for Pipeline jobs.",
-            treePruneSupported = true)
+            treePruneSupported = true,
+            annotations = @Tool.Annotations(destructiveHint = false))
     public QueueItem replayBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -122,8 +122,7 @@ public class DefaultMcpServer implements McpServerExtension {
 
     @Tool(
             description = "Trigger a build for a Jenkins job",
-            treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = true))
+            treePruneSupported = true)
     public QueueItem triggerBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "Build parameters (optional, e.g., {key1=value1,key2=value2})", required = false)
@@ -318,8 +317,7 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description =
                     "Rebuild a Jenkins build: re-run with the same parameters (and for Pipeline jobs, the same script when possible). Returns the queue item for the new build.",
-            treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = true))
+            treePruneSupported = true)
     public QueueItem rebuildBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -387,8 +385,7 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description =
                     "Replay a Pipeline build with optionally modified script(s). Runs the job again with the given main script and optional loaded scripts. Only available for Pipeline jobs.",
-            treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = true))
+            treePruneSupported = true)
     public QueueItem replayBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -120,9 +120,7 @@ public class DefaultMcpServer implements McpServerExtension {
         }
     }
 
-    @Tool(
-            description = "Trigger a build for a Jenkins job",
-            treePruneSupported = true)
+    @Tool(description = "Trigger a build for a Jenkins job", treePruneSupported = true)
     public QueueItem triggerBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "Build parameters (optional, e.g., {key1=value1,key2=value2})", required = false)

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -123,7 +123,7 @@ public class DefaultMcpServer implements McpServerExtension {
     @Tool(
             description = "Trigger a build for a Jenkins job",
             treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(destructiveHint = true))
     public QueueItem triggerBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @ToolParam(description = "Build parameters (optional, e.g., {key1=value1,key2=value2})", required = false)
@@ -319,7 +319,7 @@ public class DefaultMcpServer implements McpServerExtension {
             description =
                     "Rebuild a Jenkins build: re-run with the same parameters (and for Pipeline jobs, the same script when possible). Returns the queue item for the new build.",
             treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(destructiveHint = true))
     public QueueItem rebuildBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -388,7 +388,7 @@ public class DefaultMcpServer implements McpServerExtension {
             description =
                     "Replay a Pipeline build with optionally modified script(s). Runs the job again with the given main script and optional loaded scripts. Only available for Pipeline jobs.",
             treePruneSupported = true,
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(destructiveHint = true))
     public QueueItem replayBuild(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/JobScmExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/JobScmExtension.java
@@ -62,7 +62,7 @@ public class JobScmExtension implements McpServerExtension {
 
     @Tool(
             description = "Retrieves scm configurations of a Jenkins job",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public List getJobScm(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName) {
         var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
@@ -85,7 +85,7 @@ public class JobScmExtension implements McpServerExtension {
 
     @Tool(
             description = "Retrieves scm configurations of a Jenkins build",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public List getBuildScm(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -105,7 +105,7 @@ public class JobScmExtension implements McpServerExtension {
 
     @Tool(
             description = "Retrieves change log sets of a Jenkins build",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public List getBuildChangeSets(
             @ToolParam(description = "Full path of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -123,7 +123,7 @@ public class JobScmExtension implements McpServerExtension {
 
     @Tool(
             description = "Get a paginated list of Jenkins jobs that use the specified git SCM URL",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public List<Job> findJobsWithScmUrl(
             @ToolParam(description = "SCM URL to search for (e.g., 'git@github.com:jenkinsci/mcp-server-plugin.git')")
                     String scmUrl,

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtension.java
@@ -23,7 +23,7 @@ public class TestResultExtension implements McpServerExtension {
 
     @Tool(
             description = "Retrieves the test results associated to a Jenkins build",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public Map<String, Object> getTestResults(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable
@@ -65,7 +65,7 @@ public class TestResultExtension implements McpServerExtension {
 
     @Tool(
             description = "Retrieves the flaky failures associated to a Jenkins build if any found",
-            annotations = @Tool.Annotations(destructiveHint = false))
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public Map<String, Object> getFlakyFailures(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
             @Nullable

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -85,11 +85,11 @@ public class EndPointTest {
                 assertThat(toolsByName.get(name).annotations().readOnlyHint()).isTrue();
                 assertThat(toolsByName.get(name).annotations().destructiveHint()).isFalse();
             };
-            Consumer<String> assertAdditiveMutation = name -> {
+            Consumer<String> assertDestructiveMutation = name -> {
                 assertThat(toolsByName).containsKey(name);
                 assertThat(toolsByName.get(name).annotations()).isNotNull();
                 assertThat(toolsByName.get(name).annotations().readOnlyHint()).isFalse();
-                assertThat(toolsByName.get(name).annotations().destructiveHint()).isFalse();
+                assertThat(toolsByName.get(name).annotations().destructiveHint()).isTrue();
             };
 
             for (String name : new String[] {
@@ -113,7 +113,7 @@ public class EndPointTest {
             }
 
             for (String name : new String[] {"triggerBuild", "rebuildBuild", "replayBuild"}) {
-                assertAdditiveMutation.accept(name);
+                assertDestructiveMutation.accept(name);
             }
 
             assertThat(toolsByName).containsKey("updateBuild");

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -34,6 +34,7 @@ import io.jenkins.plugins.mcp.server.junit.McpClientTest;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URL;
+import java.util.function.Consumer;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,56 @@ public class EndPointTest {
                             "getTestResults",
                             "getFlakyFailures",
                             "getQueueItem");
+        }
+    }
+
+    @McpClientTest
+    void testBuiltinToolHints(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            var toolsByName = client.listTools().tools().stream()
+                    .collect(java.util.stream.Collectors.toMap(McpSchema.Tool::name, tool -> tool));
+
+            Consumer<String> assertReadOnly = name -> {
+                assertThat(toolsByName).containsKey(name);
+                assertThat(toolsByName.get(name).annotations()).isNotNull();
+                assertThat(toolsByName.get(name).annotations().readOnlyHint()).isTrue();
+                assertThat(toolsByName.get(name).annotations().destructiveHint()).isFalse();
+            };
+            Consumer<String> assertAdditiveMutation = name -> {
+                assertThat(toolsByName).containsKey(name);
+                assertThat(toolsByName.get(name).annotations()).isNotNull();
+                assertThat(toolsByName.get(name).annotations().readOnlyHint()).isFalse();
+                assertThat(toolsByName.get(name).annotations().destructiveHint()).isFalse();
+            };
+
+            for (String name : new String[] {
+                "getBuild",
+                "getJob",
+                "getJobs",
+                "whoAmI",
+                "getStatus",
+                "getQueueItem",
+                "getReplayScripts",
+                "getBuildLog",
+                "searchBuildLog",
+                "getTestResults",
+                "getFlakyFailures",
+                "getJobScm",
+                "getBuildScm",
+                "getBuildChangeSets",
+                "findJobsWithScmUrl"
+            }) {
+                assertReadOnly.accept(name);
+            }
+
+            for (String name : new String[] {"triggerBuild", "rebuildBuild", "replayBuild"}) {
+                assertAdditiveMutation.accept(name);
+            }
+
+            assertThat(toolsByName).containsKey("updateBuild");
+            assertThat(toolsByName.get("updateBuild").annotations()).isNotNull();
+            assertThat(toolsByName.get("updateBuild").annotations().readOnlyHint()).isFalse();
+            assertThat(toolsByName.get("updateBuild").annotations().destructiveHint()).isTrue();
         }
     }
 

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -83,13 +83,15 @@ public class EndPointTest {
                 assertThat(toolsByName).containsKey(name);
                 assertThat(toolsByName.get(name).annotations()).isNotNull();
                 assertThat(toolsByName.get(name).annotations().readOnlyHint()).isTrue();
-                assertThat(toolsByName.get(name).annotations().destructiveHint()).isFalse();
+                assertThat(toolsByName.get(name).annotations().destructiveHint())
+                        .isFalse();
             };
             Consumer<String> assertDestructiveMutation = name -> {
                 assertThat(toolsByName).containsKey(name);
                 assertThat(toolsByName.get(name).annotations()).isNotNull();
                 assertThat(toolsByName.get(name).annotations().readOnlyHint()).isFalse();
-                assertThat(toolsByName.get(name).annotations().destructiveHint()).isTrue();
+                assertThat(toolsByName.get(name).annotations().destructiveHint())
+                        .isTrue();
             };
 
             for (String name : new String[] {
@@ -118,8 +120,10 @@ public class EndPointTest {
 
             assertThat(toolsByName).containsKey("updateBuild");
             assertThat(toolsByName.get("updateBuild").annotations()).isNotNull();
-            assertThat(toolsByName.get("updateBuild").annotations().readOnlyHint()).isFalse();
-            assertThat(toolsByName.get("updateBuild").annotations().destructiveHint()).isTrue();
+            assertThat(toolsByName.get("updateBuild").annotations().readOnlyHint())
+                    .isFalse();
+            assertThat(toolsByName.get("updateBuild").annotations().destructiveHint())
+                    .isTrue();
         }
     }
 


### PR DESCRIPTION
Jenkins MCP tools were under-signaling their behavior to clients: read-only tools did not advertise `readOnlyHint`, and some enqueue-style actions were still marked as destructive. This updates the exposed tool metadata so clients can distinguish pure reads, additive mutations, and truly destructive operations.

- **Tool metadata**
  - Mark read-only tools across build, job, SCM, test, log, queue, status, and identity queries with `readOnlyHint = true`.
  - Mark additive write tools (`triggerBuild`, `rebuildBuild`, `replayBuild`) with `destructiveHint = false`.
  - Leave `updateBuild` as the only built-in tool still advertising destructive behavior.

- **Coverage**
  - Add endpoint-level assertions for built-in tool annotations so the published MCP schema matches the intended semantics.


### Testing done

Added endpoint-level assertions for built-in tool annotations so the published MCP schema matches the intended semantics.
Tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
