### PR TITLE
Tool to cancel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ The plugin provides the following built-in tools for interacting with Jenkins:
 - `getReplayScripts`: Return the main script and loaded scripts of a replayable Pipeline build. Use this to inspect or modify script before calling `replayBuild`. Fails for non-Pipeline jobs. Optional `buildNumber`; defaults to the last build.
 - `replayBuild`: Run a Pipeline build again with a modified script. Provide `mainScript` (required) and optionally `loadedScripts`. Optional `buildNumber`; defaults to the last build. Fails if the build is not replayable or replay is not allowed (e.g. permissions or sandbox).
 - `getTestResults`: Retrieve test results of a specific build or the last build.
+- `cancelBuild`: Cancel a running build.
 
 #### SCM Integration
 - `getJobScm`: Retrieve SCM configurations of a Jenkins job.

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
       <artifactId>workflow-cps</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- compile time only dependencies -->
     <dependency>
@@ -236,11 +241,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -30,6 +30,7 @@ import static io.jenkins.plugins.mcp.server.extensions.util.JenkinsUtil.getBuild
 import static io.jenkins.plugins.mcp.server.extensions.util.ParameterValueFactory.createParameterValue;
 
 import hudson.Extension;
+import hudson.model.AbstractBuild;
 import hudson.model.AbstractItem;
 import hudson.model.Action;
 import hudson.model.AdministrativeMonitor;
@@ -50,6 +51,8 @@ import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import io.jenkins.plugins.mcp.server.tool.JenkinsMcpContext;
 import jakarta.annotation.Nullable;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -65,6 +68,7 @@ import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.export.Exported;
 
 @Extension
@@ -72,6 +76,35 @@ import org.kohsuke.stapler.export.Exported;
 public class DefaultMcpServer implements McpServerExtension {
 
     public static final String FULL_NAME = "fullName";
+
+    public static boolean isWorkflowJobPluginInstalled() {
+        var plugin = Jenkins.get().getPluginManager().getPlugin("workflow-job");
+        return plugin != null && plugin.isActive();
+    }
+
+    @Tool(description = "Cancel specific build")
+    public boolean cancelBuild(
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @ToolParam(description = "Build number") Integer buildNumber)
+            throws ServletException, IOException {
+        var job = Jenkins.get().getItemByFullName(jobFullName, Job.class);
+        if (job == null || !job.hasPermission(Item.CANCEL)) {
+            return false;
+        }
+
+        var build = job.getBuildByNumber(buildNumber);
+        if (build == null || !build.isBuilding()) {
+            return false;
+        }
+        if (build instanceof AbstractBuild<?, ?> ab) {
+            ab.doStop();
+        } else if (isWorkflowJobPluginInstalled() && build instanceof WorkflowRun wr) {
+            wr.doStop();
+        } else {
+            return false;
+        }
+        return true;
+    }
 
     @Tool(
             description = "Get a specific build or the last build of a Jenkins job",

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -69,7 +69,8 @@ public class EndPointTest {
                             "getStatus",
                             "getTestResults",
                             "getFlakyFailures",
-                            "getQueueItem");
+                            "getQueueItem",
+                            "cancelBuild");
         }
     }
 

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/CancelBuildTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/CancelBuildTest.java
@@ -1,0 +1,170 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static io.jenkins.plugins.mcp.server.junit.TestUtils.MIN_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.jenkins.plugins.mcp.server.junit.TestUtils;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class CancelBuildTest {
+
+    static Stream<Arguments> cancelBuildTestParameters() {
+        Stream<Arguments> baseArgs = Stream.of(
+                // run already finished
+                Arguments.of("canceller", 1, "pipeline", false, true),
+                // run successfully cancelled
+                Arguments.of("canceller", 2, "pipeline", true, false),
+                // run not existing
+                Arguments.of("canceller", 3, "pipeline", false, true),
+                // job not existing
+                Arguments.of("canceller", 1, "missing", false, true),
+                // missing permission to cancel
+                Arguments.of("reader", 2, "pipeline", false, true),
+                // missing permission to see job
+                Arguments.of("unknown", 2, "pipeline", false, true));
+        return TestUtils.appendMcpClientArgs(baseArgs);
+    }
+
+    @ParameterizedTest
+    @MethodSource("cancelBuildTestParameters")
+    void testMcpToolCallCancelBuildPipeline(
+            String user,
+            int buildNumber,
+            String jobNameToCancel,
+            boolean expectedResults,
+            boolean expectedRunning,
+            JenkinsMcpClientBuilder jenkinsMcpClientBuilder,
+            JenkinsRule jenkins)
+            throws Exception {
+        enableSecurity(jenkins);
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "pipeline");
+        project.setDefinition(new CpsFlowDefinition("", true));
+        var finishedBuild = project.scheduleBuild2(0).get();
+        assertThat(finishedBuild.isBuilding()).isFalse();
+        project.setDefinition(new CpsFlowDefinition("sleep 30", true));
+        var runningBuild = project.scheduleBuild2(0).waitForStart();
+
+        String authString = user + ":" + user;
+        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
+        try (var client = jenkinsMcpClientBuilder
+                .jenkins(jenkins)
+                .requestCustomizer((builder, method, endpoint, body, context) ->
+                        builder.setHeader("Authorization", "Basic " + encodedAuth))
+                .build()) {
+            {
+                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                        "cancelBuild", Map.of("jobFullName", jobNameToCancel, "buildNumber", buildNumber), null);
+
+                var response = client.callTool(request);
+                assertThat(response.isError()).isFalse();
+                assertThat(response.content().get(0).type()).isEqualTo("text");
+                assertThat(response.content())
+                        .first()
+                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                            assertThat(textContent.type()).isEqualTo("text");
+                            assertThat(textContent.text()).contains(String.valueOf(expectedResults));
+                        });
+                TimeUnit.SECONDS.sleep(2);
+                assertThat(runningBuild.isBuilding()).isEqualTo(expectedRunning);
+                runningBuild.doStop();
+            }
+        }
+        jenkins.waitUntilNoActivityUpTo(MIN_1);
+    }
+
+    @McpClientTest
+    void testMcpToolCallCancelBuildFreestyle(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        enableSecurity(jenkins);
+        FreeStyleProject project = jenkins.createFreeStyleProject("freestyle");
+        project.getBuildersList().add(new SleepBuilder(30000));
+        var build = project.scheduleBuild2(0).waitForStart();
+
+        String username = "admin";
+        String password = "admin";
+        String authString = username + ":" + password;
+        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
+        try (var client = jenkinsMcpClientBuilder
+                .jenkins(jenkins)
+                .requestCustomizer((builder, method, endpoint, body, context) ->
+                        builder.setHeader("Authorization", "Basic " + encodedAuth))
+                .build()) {
+            {
+                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                        "cancelBuild", Map.of("jobFullName", "freestyle", "buildNumber", 1), null);
+
+                var response = client.callTool(request);
+                assertThat(response.isError()).isFalse();
+                assertThat(response.content().get(0).type()).isEqualTo("text");
+                assertThat(response.content())
+                        .first()
+                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                            assertThat(textContent.type()).isEqualTo("text");
+                            assertThat(textContent.text()).contains("true");
+                        });
+
+                assertThat(build.isBuilding()).isFalse();
+            }
+        }
+        jenkins.waitUntilNoActivityUpTo(MIN_1);
+    }
+
+    private void enableSecurity(JenkinsRule jenkins) throws Exception {
+        JenkinsRule.DummySecurityRealm securityRealm = jenkins.createDummySecurityRealm();
+        jenkins.jenkins.setSecurityRealm(securityRealm);
+        var authStrategy = new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER)
+                .everywhere()
+                .to("admin");
+        authStrategy.grant(Jenkins.READ).everywhere().toEveryone();
+        authStrategy.grant(Item.READ).everywhere().to("canceller", "reader");
+        authStrategy.grant(Item.CANCEL).everywhere().to("canceller");
+        jenkins.jenkins.setAuthorizationStrategy(authStrategy);
+        jenkins.jenkins.save();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -37,6 +37,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.ChoiceParameterDefinition;
+import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
@@ -56,6 +57,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -407,6 +409,92 @@ class DefaultMcpServerTest {
                         });
             }
         }
+    }
+
+    static Stream<Arguments> cancelBuildTestParameters() {
+        Stream<Arguments> baseArgs = Stream.of(
+                // security enable, no auth -> no, AccessDenied
+                Arguments.of(true, false, true, "AccessDenied", false),
+                // security enable, auth -> no, triggered
+                Arguments.of(true, true, false, "COMPLETED", true),
+                // security not enable, no auth -> run triggered yeah freedom!
+                Arguments.of(false, false, false, "COMPLETED", true),
+                // security not enable, auth -> run triggered root is the king
+                Arguments.of(false, true, false, "COMPLETED", true));
+        return TestUtils.appendMcpClientArgs(baseArgs);
+    }
+
+    @McpClientTest
+    void testMcpToolCallCancelBuildPipeline(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        enableSecurity(jenkins);
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
+        project.setDefinition(new CpsFlowDefinition("sleep 30", true));
+        var build = project.scheduleBuild2(0).get();
+
+        String username = "admin";
+        String password = "admin";
+        String authString = username + ":" + password;
+        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
+        try (var client = jenkinsMcpClientBuilder
+                .jenkins(jenkins)
+                .requestCustomizer((builder, method, endpoint, body, context) ->
+                        builder.setHeader("Authorization", "Basic " + encodedAuth))
+                .build()) {
+            {
+                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                        "cancelBuild", Map.of("jobFullName", "demo-job", "buildNumber", 1), null);
+
+                var response = client.callTool(request);
+                assertThat(response.isError()).isFalse();
+                assertThat(response.content().get(0).type()).isEqualTo("text");
+                assertThat(response.content())
+                        .first()
+                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                            assertThat(textContent.type()).isEqualTo("text");
+                            assertThat(textContent.text()).contains("true");
+                        });
+                assertThat(build.isBuilding()).isFalse();
+            }
+        }
+        jenkins.waitUntilNoActivityUpTo(MIN_1);
+    }
+
+    @McpClientTest
+    void testMcpToolCallCancelBuildFreestyle(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        enableSecurity(jenkins);
+        FreeStyleProject project = jenkins.createFreeStyleProject("freestyle");
+        project.getBuildersList().add(new SleepBuilder(30000));
+        var build = project.scheduleBuild2(0).get();
+
+        String username = "admin";
+        String password = "admin";
+        String authString = username + ":" + password;
+        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
+        try (var client = jenkinsMcpClientBuilder
+                .jenkins(jenkins)
+                .requestCustomizer((builder, method, endpoint, body, context) ->
+                        builder.setHeader("Authorization", "Basic " + encodedAuth))
+                .build()) {
+            {
+                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                        "cancelBuild", Map.of("jobFullName", "freestyle", "buildNumber", 1), null);
+
+                var response = client.callTool(request);
+                assertThat(response.isError()).isFalse();
+                assertThat(response.content().get(0).type()).isEqualTo("text");
+                assertThat(response.content())
+                        .first()
+                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                            assertThat(textContent.type()).isEqualTo("text");
+                            assertThat(textContent.text()).contains("true");
+                        });
+
+                assertThat(build.isBuilding()).isFalse();
+            }
+        }
+        jenkins.waitUntilNoActivityUpTo(MIN_1);
     }
 
     private void enableSecurity(JenkinsRule jenkins) throws Exception {

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -37,7 +37,6 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.ChoiceParameterDefinition;
-import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
@@ -57,7 +56,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -409,92 +407,6 @@ class DefaultMcpServerTest {
                         });
             }
         }
-    }
-
-    static Stream<Arguments> cancelBuildTestParameters() {
-        Stream<Arguments> baseArgs = Stream.of(
-                // security enable, no auth -> no, AccessDenied
-                Arguments.of(true, false, true, "AccessDenied", false),
-                // security enable, auth -> no, triggered
-                Arguments.of(true, true, false, "COMPLETED", true),
-                // security not enable, no auth -> run triggered yeah freedom!
-                Arguments.of(false, false, false, "COMPLETED", true),
-                // security not enable, auth -> run triggered root is the king
-                Arguments.of(false, true, false, "COMPLETED", true));
-        return TestUtils.appendMcpClientArgs(baseArgs);
-    }
-
-    @McpClientTest
-    void testMcpToolCallCancelBuildPipeline(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
-            throws Exception {
-        enableSecurity(jenkins);
-        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "demo-job");
-        project.setDefinition(new CpsFlowDefinition("sleep 30", true));
-        var build = project.scheduleBuild2(0).get();
-
-        String username = "admin";
-        String password = "admin";
-        String authString = username + ":" + password;
-        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
-        try (var client = jenkinsMcpClientBuilder
-                .jenkins(jenkins)
-                .requestCustomizer((builder, method, endpoint, body, context) ->
-                        builder.setHeader("Authorization", "Basic " + encodedAuth))
-                .build()) {
-            {
-                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
-                        "cancelBuild", Map.of("jobFullName", "demo-job", "buildNumber", 1), null);
-
-                var response = client.callTool(request);
-                assertThat(response.isError()).isFalse();
-                assertThat(response.content().get(0).type()).isEqualTo("text");
-                assertThat(response.content())
-                        .first()
-                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
-                            assertThat(textContent.type()).isEqualTo("text");
-                            assertThat(textContent.text()).contains("true");
-                        });
-                assertThat(build.isBuilding()).isFalse();
-            }
-        }
-        jenkins.waitUntilNoActivityUpTo(MIN_1);
-    }
-
-    @McpClientTest
-    void testMcpToolCallCancelBuildFreestyle(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
-            throws Exception {
-        enableSecurity(jenkins);
-        FreeStyleProject project = jenkins.createFreeStyleProject("freestyle");
-        project.getBuildersList().add(new SleepBuilder(30000));
-        var build = project.scheduleBuild2(0).get();
-
-        String username = "admin";
-        String password = "admin";
-        String authString = username + ":" + password;
-        String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes());
-        try (var client = jenkinsMcpClientBuilder
-                .jenkins(jenkins)
-                .requestCustomizer((builder, method, endpoint, body, context) ->
-                        builder.setHeader("Authorization", "Basic " + encodedAuth))
-                .build()) {
-            {
-                McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
-                        "cancelBuild", Map.of("jobFullName", "freestyle", "buildNumber", 1), null);
-
-                var response = client.callTool(request);
-                assertThat(response.isError()).isFalse();
-                assertThat(response.content().get(0).type()).isEqualTo("text");
-                assertThat(response.content())
-                        .first()
-                        .isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
-                            assertThat(textContent.type()).isEqualTo("text");
-                            assertThat(textContent.text()).contains("true");
-                        });
-
-                assertThat(build.isBuilding()).isFalse();
-            }
-        }
-        jenkins.waitUntilNoActivityUpTo(MIN_1);
     }
 
     private void enableSecurity(JenkinsRule jenkins) throws Exception {


### PR DESCRIPTION
Add the tool `cancelBuild`.  Requires the parameters `jobFullName` and `buildNumber`. Performs relevant checks upfront. While the doStop methods perform permission checks themselves, they only return httpresponses which is a bit arkward to work with. So when we call `doStop` we can be sure we're allowed to cancel.

fixes #189

<!-- Please describe your pull request here. -->

### Testing done
Full unit test coverage check various scenarios

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
