### PR TITLE
fix: exclude nodeId, enclosingBlocks, and enclosingBlockNames from test results at all depths

### DIFF
--- a/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
@@ -35,6 +35,7 @@ import org.kohsuke.stapler.export.Flavor;
 import org.kohsuke.stapler.export.Model;
 import org.kohsuke.stapler.export.ModelBuilder;
 import org.kohsuke.stapler.export.NamedPathPruner;
+import org.kohsuke.stapler.export.Property;
 import org.kohsuke.stapler.export.TreePruner;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
@@ -46,12 +47,35 @@ public class JenkinsExportedBeanSerializer extends ValueSerializer<Object> {
     // remove some values which are not useful in the JSON output
     private static final List<String> EXCLUDED_PROPERTIES = List.of("enclosingBlocks", "nodeId");
 
-    private static final TreePruner CLEANER_PRUNER = new TreePruner() {
-        @Override
-        public TreePruner accept(Object node, org.kohsuke.stapler.export.Property prop) {
-            return EXCLUDED_PROPERTIES.contains(prop.name) ? null : TreePruner.DEFAULT;
+    private static final class ExclusionPruner extends TreePruner {
+        private final TreePruner delegate;
+        private ExclusionPruner next;
+
+        private ExclusionPruner(TreePruner delegate) {
+            this.delegate = delegate;
         }
-    };
+
+        @Override
+        public TreePruner accept(Object node, Property prop) {
+            if (EXCLUDED_PROPERTIES.contains(prop.name)) {
+                return null;
+            }
+            TreePruner child = delegate.accept(node, prop);
+            if (child == null) {
+                return null;
+            }
+            if (child == delegate) {
+                // delegate did not advance depth (inline/merge property), as done in ByDepth#accept
+                return this;
+            }
+            if (next == null) {
+                next = new ExclusionPruner(child);
+            }
+            return next;
+        }
+    }
+
+    private static final TreePruner CLEANER_PRUNER = new ExclusionPruner(new TreePruner.ByDepth(1));
 
     @Override
     public void serialize(Object value, JsonGenerator gen, SerializationContext serializers) {

--- a/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
@@ -45,7 +45,8 @@ public class JenkinsExportedBeanSerializer extends ValueSerializer<Object> {
 
     private static final ModelBuilder MODEL_BUILDER = new ModelBuilder();
     // remove some values which are not useful in the JSON output
-    private static final List<String> EXCLUDED_PROPERTIES = List.of("enclosingBlocks", "nodeId");
+    private static final List<String> EXCLUDED_PROPERTIES =
+            List.of("enclosingBlocks", "enclosingBlockNames", "nodeId");
 
     private static final class ExclusionPruner extends TreePruner {
         private final TreePruner delegate;

--- a/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
@@ -75,7 +75,7 @@ public class JenkinsExportedBeanSerializer extends ValueSerializer<Object> {
         }
     }
 
-    private static final TreePruner CLEANER_PRUNER = new ExclusionPruner(new TreePruner.ByDepth(1));
+    private static final TreePruner CLEANER_PRUNER = new ExclusionPruner(new TreePruner.ByDepth(0));
 
     @Override
     public void serialize(Object value, JsonGenerator gen, SerializationContext serializers) {

--- a/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java
@@ -45,8 +45,7 @@ public class JenkinsExportedBeanSerializer extends ValueSerializer<Object> {
 
     private static final ModelBuilder MODEL_BUILDER = new ModelBuilder();
     // remove some values which are not useful in the JSON output
-    private static final List<String> EXCLUDED_PROPERTIES =
-            List.of("enclosingBlocks", "enclosingBlockNames", "nodeId");
+    private static final List<String> EXCLUDED_PROPERTIES = List.of("enclosingBlocks", "enclosingBlockNames", "nodeId");
 
     private static final class ExclusionPruner extends TreePruner {
         private final TreePruner delegate;

--- a/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
@@ -122,5 +122,8 @@ public class JenkinsObjectSerializationTest {
         assertThat((List<?>) doc.read("$..nodeId")).isEmpty();
         assertThat((List<?>) doc.read("$..enclosingBlocks")).isEmpty();
         assertThat((List<?>) doc.read("$..enclosingBlockNames")).isEmpty();
+
+        assertThat((List<?>) doc.read("$..cases[*].errorDetails"))
+                .anySatisfy(v -> assertThat(v).isNotNull());
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
@@ -28,10 +28,18 @@ package io.jenkins.plugins.mcp.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import hudson.FilePath;
 import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.tasks.junit.TestResultAction;
+import io.jenkins.plugins.mcp.server.extensions.TestResultExtensionTest;
 import io.jenkins.plugins.mcp.server.jackson.JenkinsExportedBeanModule;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -83,5 +91,35 @@ public class JenkinsObjectSerializationTest {
         var json = objectMapper.writeValueAsString(Map.of("key", "value", "key1", "value1"));
         var map = new JsonMapper().readValue(json, Map.class);
         assertThat(map).extractingByKey("key").isEqualTo("value");
+    }
+
+    @Test
+    void testExcludedPropertiesCascadeIntoNestedBeans(JenkinsRule jenkins) throws Exception {
+        // Given a pipeline run with junit inside stage { node { } }, which sets SuiteResult.nodeId
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "junit-cascade");
+        project.setDefinition(new CpsFlowDefinition("""
+                        stage('first') {
+                          node {
+                            def results = junit(testResults: '*.xml')
+                            assert results.totalCount == 6
+                          }
+                        }
+                        """, true));
+        FilePath ws = jenkins.jenkins.getWorkspaceFor(project);
+        Objects.requireNonNull(ws)
+                .child("test-result.xml")
+                .copyFrom(TestResultExtensionTest.class.getResource("junit-report-20090516.xml"));
+
+        // When the TestResult is serialized
+        var run = jenkins.buildAndAssertStatus(Result.FAILURE, project);
+        var testResult = run.getAction(TestResultAction.class).getResult();
+        assertThat(testResult.getSuites().iterator().next().getNodeId()).isNotNull();
+
+        var json = objectMapper.writeValueAsString(testResult);
+        var doc = JsonPath.using(Configuration.defaultConfiguration()).parse(json);
+
+        // Then nodeId and enclosingBlocks are absent at every depth
+        assertThat((List<?>) doc.read("$..nodeId")).isEmpty();
+        assertThat((List<?>) doc.read("$..enclosingBlocks")).isEmpty();
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/JenkinsObjectSerializationTest.java
@@ -118,8 +118,9 @@ public class JenkinsObjectSerializationTest {
         var json = objectMapper.writeValueAsString(testResult);
         var doc = JsonPath.using(Configuration.defaultConfiguration()).parse(json);
 
-        // Then nodeId and enclosingBlocks are absent at every depth
+        // Then nodeId, enclosingBlocks and enclosingBlockNames are absent at every depth
         assertThat((List<?>) doc.read("$..nodeId")).isEmpty();
         assertThat((List<?>) doc.read("$..enclosingBlocks")).isEmpty();
+        assertThat((List<?>) doc.read("$..enclosingBlockNames")).isEmpty();
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
@@ -97,6 +97,9 @@ public class TestResultExtensionTest {
                 assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlockNames"))
                         .isEmpty();
 
+                assertThat((List<Object>) documentContext.read("$..cases[*].errorDetails"))
+                        .anySatisfy(v -> assertThat(v).isNotNull());
+
                 List<Object> list = documentContext.read("$..suites");
                 assertThat(list).size().isEqualTo(testResult.getSuites().size());
 

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
@@ -90,6 +90,11 @@ public class TestResultExtensionTest {
                 assertThat(documentContext.read("$.failCount", Integer.class)).isEqualTo(testResult.getFailCount());
                 assertThat(documentContext.read("$.passCount", Integer.class)).isEqualTo(testResult.getPassCount());
 
+                assertThat((List<Object>) documentContext.read("$..suites[*].nodeId"))
+                        .isEmpty();
+                assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlocks"))
+                        .isEmpty();
+
                 List<Object> list = documentContext.read("$..suites");
                 assertThat(list).size().isEqualTo(testResult.getSuites().size());
 
@@ -258,6 +263,11 @@ public class TestResultExtensionTest {
                                 .mapToLong(Collection::size)
                                 .sum());
                 assertThat(list).size().isEqualTo(4); // There are 4 flaky failures in the four reports
+
+                assertThat((List<Object>) documentContext.read("$..suites[*].nodeId"))
+                        .isEmpty();
+                assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlocks"))
+                        .isEmpty();
             }
         }
     }

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/TestResultExtensionTest.java
@@ -94,6 +94,8 @@ public class TestResultExtensionTest {
                         .isEmpty();
                 assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlocks"))
                         .isEmpty();
+                assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlockNames"))
+                        .isEmpty();
 
                 List<Object> list = documentContext.read("$..suites");
                 assertThat(list).size().isEqualTo(testResult.getSuites().size());
@@ -267,6 +269,8 @@ public class TestResultExtensionTest {
                 assertThat((List<Object>) documentContext.read("$..suites[*].nodeId"))
                         .isEmpty();
                 assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlocks"))
+                        .isEmpty();
+                assertThat((List<Object>) documentContext.read("$..suites[*].enclosingBlockNames"))
                         .isEmpty();
             }
         }


### PR DESCRIPTION
amends #85

`EXCLUDED_PROPERTIES` only filtered at the root level of serialization
https://github.com/jenkinsci/mcp-server-plugin/blob/bd1125775e095a84119b159e66c8e7dd8b064d4d/src/main/java/io/jenkins/plugins/mcp/server/jackson/JenkinsExportedBeanSerializer.java#L52
`TreePruner.DEFAULT`(`=ByDepth(1)`) for allowed properties, handing off to all child nodes without knowledge of the exclusion list.

So, a Pipeline build with `junit` inside `stage { node { } }` populates `SuiteResult.nodeId/enclosingBlocks` (with  `@Exported(visibility = 9)`), which ended up in `getTestResults` output.

<details>
<summary>testMcpToolCallGetTestResults before fix</summary>

```json
{
  "_class" : "hudson.tasks.junit.TestResult",
  "testActions" : [ ],
  "duration" : 14.398,
  "empty" : false,
  "failCount" : 3,
  "passCount" : 5,
  "skipCount" : 0,
  "suites" : [ {
    "cases" : [ {
      "testActions" : [ ],
      "age" : 1,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 3.377,
      "errorDetails" : null,
      "errorStackTrace" : "java.lang.NullPointerException\r\n       at org.twia.vendor.VendorManagerTest.testGetVendorFirmKeyForVendorRep(VendorManagerTest.java:104)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at junit.framework.TestCase.runTest(TestCase.java:166)\r\n       at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)\r\n       at junit.framework.TestCase.runBare(TestCase.java:140)\r\n       at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)\r\n       at junit.framework.TestResult$1.protect(TestResult.java:106)\r\n       at junit.framework.TestResult.runProtected(TestResult.java:124)\r\n       at junit.framework.TestResult.run(TestResult.java:109)\r\n       at junit.framework.TestCase.run(TestCase.java:131)\r\n       at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.textui.TestRunner.doRun(TestRunner.java:74)\r\n       at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)\r\n       at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\r\n       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\r\n       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\r\n       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\r\n       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\r\n       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\r\n       at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\r\n       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\r\n       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\r\n       at org.jboss.ejb.Container.invoke(Container.java:960)\r\n       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)\r\n       at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)\r\n       at $Proxy16.invoke(Unknown Source)\r\n       at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)\r\n       at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)\r\n       at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)\r\n       at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)\r\n",
      "failedSince" : 1,
      "flakyFailures" : [ ],
      "name" : "testGetVendorFirmKeyForVendorRep",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "FAILED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 1,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 3.267,
      "errorDetails" : "RuntimeException; nested exception is: \n\tjava.lang.IllegalArgumentException: id to load is required for loading",
      "errorStackTrace" : "java.rmi.ServerException: RuntimeException; nested exception is:\n       java.lang.IllegalArgumentException: id to load is required for loading\r\n       at org.jboss.ejb.plugins.LogInterceptor.handleException(LogInterceptor.java:421)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:209)\r\n       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\r\n       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\r\n       at org.jboss.ejb.Container.invoke(Container.java:960)\r\n       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at org.jboss.invocation.local.LocalInvoker$MBeanServerAction.invoke(LocalInvoker.java:169)\r\n       at org.jboss.invocation.local.LocalInvoker.invoke(LocalInvoker.java:118)\r\n       at org.jboss.invocation.InvokerInterceptor.invokeLocal(InvokerInterceptor.java:209)\r\n       at org.jboss.invocation.InvokerInterceptor.invoke(InvokerInterceptor.java:195)\r\n       at org.jboss.proxy.TransactionInterceptor.invoke(TransactionInterceptor.java:61)\r\n       at org.jboss.proxy.SecurityInterceptor.invoke(SecurityInterceptor.java:70)\r\n       at org.jboss.proxy.ejb.StatelessSessionInterceptor.invoke(StatelessSessionInterceptor.java:112)\r\n       at org.jboss.proxy.ClientContainer.invoke(ClientContainer.java:100)\r\n       at $Proxy108.assignAdjustingFirmAndLocation(Unknown Source)\r\n       at org.twia.vendor.VendorManagerTest.testGetRevokedClaimsForAdjustingFirm(VendorManagerTest.java:120)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at junit.framework.TestCase.runTest(TestCase.java:166)\r\n       at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)\r\n       at junit.framework.TestCase.runBare(TestCase.java:140)\r\n       at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)\r\n       at junit.framework.TestResult$1.protect(TestResult.java:106)\r\n       at junit.framework.TestResult.runProtected(TestResult.java:124)\r\n       at junit.framework.TestResult.run(TestResult.java:109)\r\n       at junit.framework.TestCase.run(TestCase.java:131)\r\n       at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.textui.TestRunner.doRun(TestRunner.java:74)\r\n       at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)\r\n       at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\r\n       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\r\n       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\r\n       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\r\n       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\r\n       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\r\n       at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\r\n       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\r\n       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\r\n       at org.jboss.ejb.Container.invoke(Container.java:960)\r\n       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)\r\n       at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)\r\n       at $Proxy16.invoke(Unknown Source)\r\n       at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)\r\n       at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)\r\n       at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)\r\n       at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)\r\nCaused by: java.lang.IllegalArgumentException: id to load is required for loading\r\n       at org.hibernate.event.LoadEvent.<init>(LoadEvent.java:51)\r\n       at org.hibernate.event.LoadEvent.<init>(LoadEvent.java:33)\r\n       at org.hibernate.impl.SessionImpl.get(SessionImpl.java:812)\r\n       at org.hibernate.impl.SessionImpl.get(SessionImpl.java:808)\r\n       at org.twia.persistence.hibernate.HibernateDAO.reloadWithVersionCheck(HibernateDAO.java:712)\r\n       at org.twia.persistence.hibernate.HibernateDAO.reloadWithVersionCheck(HibernateDAO.java:782)\r\n       at org.twia.claim.ClaimManager.assignAdjustingFirmAndLocation(ClaimManager.java:3119)\r\n       at org.twia.claim.ClaimManager.assignAdjustingFirmAndLocation(ClaimManager.java:3092)\r\n       at org.twia.claim.ClaimManagerSessionEJB.assignAdjustingFirmAndLocation(ClaimManagerSessionEJB.java:547)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\r\n       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\r\n       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\r\n       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\r\n       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\r\n       at org.jboss.ejb.plugins.AbstractInterceptor.invoke(AbstractInterceptor.java:111)\r\n       at org.twia.stats.StatisticsInterceptor.invoke(StatisticsInterceptor.java:79)\r\n       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:350)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\r\n       at org.twia.security.SecurityInterceptor.invoke(SecurityInterceptor.java:105)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\r\n       ... 81 more\r\n",
      "failedSince" : 1,
      "flakyFailures" : [ ],
      "name" : "testGetRevokedClaimsForAdjustingFirm",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "FAILED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 0,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 1.798,
      "errorDetails" : null,
      "errorStackTrace" : null,
      "failedSince" : 0,
      "flakyFailures" : [ ],
      "name" : "testCreateVendorFirm",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "PASSED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 0,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 0.953,
      "errorDetails" : null,
      "errorStackTrace" : null,
      "failedSince" : 0,
      "flakyFailures" : [ ],
      "name" : "testUpdateVendorFirm",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "PASSED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 0,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 2.502,
      "errorDetails" : null,
      "errorStackTrace" : null,
      "failedSince" : 0,
      "flakyFailures" : [ ],
      "name" : "testAddVendorLocation",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "PASSED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 0,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 0.828,
      "errorDetails" : null,
      "errorStackTrace" : null,
      "failedSince" : 0,
      "flakyFailures" : [ ],
      "name" : "testCreateVendor_NoPrimaryLocation",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "PASSED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 0,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 0.876,
      "errorDetails" : null,
      "errorStackTrace" : null,
      "failedSince" : 0,
      "flakyFailures" : [ ],
      "name" : "testCreateVendor_NoPrimaryRep",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "PASSED",
      "stderr" : null,
      "stdout" : null
    }, {
      "testActions" : [ ],
      "age" : 1,
      "className" : "org.twia.vendor.VendorManagerTest",
      "duration" : 0.766,
      "errorDetails" : "RuntimeException; nested exception is: \n\torg.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] : \n\tid = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}.",
      "errorStackTrace" : "java.rmi.ServerException: RuntimeException; nested exception is:\n       org.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] :\n       id = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}.\r\n       at org.jboss.ejb.plugins.LogInterceptor.handleException(LogInterceptor.java:421)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:209)\r\n       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\r\n       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\r\n       at org.jboss.ejb.Container.invoke(Container.java:960)\r\n       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at org.jboss.invocation.local.LocalInvoker$MBeanServerAction.invoke(LocalInvoker.java:169)\r\n       at org.jboss.invocation.local.LocalInvoker.invoke(LocalInvoker.java:118)\r\n       at org.jboss.invocation.InvokerInterceptor.invokeLocal(InvokerInterceptor.java:209)\r\n       at org.jboss.invocation.InvokerInterceptor.invoke(InvokerInterceptor.java:195)\r\n       at org.jboss.proxy.TransactionInterceptor.invoke(TransactionInterceptor.java:61)\r\n       at org.jboss.proxy.SecurityInterceptor.invoke(SecurityInterceptor.java:70)\r\n       at org.jboss.proxy.ejb.StatelessSessionInterceptor.invoke(StatelessSessionInterceptor.java:112)\r\n       at org.jboss.proxy.ClientContainer.invoke(ClientContainer.java:100)\r\n       at $Proxy108.updateClaim(Unknown Source)\r\n       at org.twia.vendor.VendorManagerTest.testCreateAdjustingFirm(VendorManagerTest.java:259)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at junit.framework.TestCase.runTest(TestCase.java:166)\r\n       at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)\r\n       at junit.framework.TestCase.runBare(TestCase.java:140)\r\n       at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)\r\n       at junit.framework.TestResult$1.protect(TestResult.java:106)\r\n       at junit.framework.TestResult.runProtected(TestResult.java:124)\r\n       at junit.framework.TestResult.run(TestResult.java:109)\r\n       at junit.framework.TestCase.run(TestCase.java:131)\r\n       at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.framework.TestSuite.runTest(TestSuite.java:173)\r\n       at junit.framework.TestSuite.run(TestSuite.java:168)\r\n       at junit.textui.TestRunner.doRun(TestRunner.java:74)\r\n       at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)\r\n       at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\r\n       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\r\n       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\r\n       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\r\n       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\r\n       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\r\n       at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\r\n       at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)\r\n       at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)\r\n       at org.jboss.ejb.Container.invoke(Container.java:960)\r\n       at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)\r\n       at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)\r\n       at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)\r\n       at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)\r\n       at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)\r\n       at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)\r\n       at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)\r\n       at $Proxy16.invoke(Unknown Source)\r\n       at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)\r\n       at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)\r\n       at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)\r\n       at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)\r\nCaused by: org.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] :\n       id = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}.\r\n       at org.twia.persistence.hibernate.HibernateDAO.handleHibernateException(HibernateDAO.java:274)\r\n       at org.twia.persistence.hibernate.HibernateDAO.handleHibernateException(HibernateDAO.java:242)\r\n       at org.twia.persistence.hibernate.HibernateDAO.update(HibernateDAO.java:443)\r\n       at org.twia.claim.ClaimManager.updateClaim(ClaimManager.java:4475)\r\n       at org.twia.claim.ClaimManagerSessionEJB.updateClaim(ClaimManagerSessionEJB.java:68)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r\n       at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)\r\n       at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)\r\n       at java.lang.reflect.Method.invoke(Method.java:585)\r\n       at org.jboss.invocation.Invocation.performCall(Invocation.java:359)\r\n       at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)\r\n       at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)\r\n       at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)\r\n       at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)\r\n       at org.jboss.ejb.plugins.AbstractInterceptor.invoke(AbstractInterceptor.java:111)\r\n       at org.twia.stats.StatisticsInterceptor.invoke(StatisticsInterceptor.java:79)\r\n       at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:350)\r\n       at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)\r\n       at org.twia.security.SecurityInterceptor.invoke(SecurityInterceptor.java:105)\r\n       at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)\r\n       ... 81 more\r\n",
      "failedSince" : 1,
      "flakyFailures" : [ ],
      "name" : "testCreateAdjustingFirm",
      "properties" : { },
      "rerunFailures" : [ ],
      "skipped" : false,
      "skippedMessage" : null,
      "status" : "FAILED",
      "stderr" : null,
      "stdout" : null
    } ],
    "duration" : 14.398,
    "enclosingBlockNames" : [ "first" ],
    "enclosingBlocks" : [ "4" ],
    "id" : null,
    "name" : "(test-result.xml)",
    "nodeId" : "7",
    "properties" : { },
    "stderr" : null,
    "stdout" : null,
    "timestamp" : null
  } ]
}

```

</details>

:speaking_head:  spotted while checking jenkinsci/stapler#788 , which proposes removing `TreePruner.DEFAULT`.
The fix here also removes the dependency on it.

## How
`CLEANER_PRUNER` is replaced with a decorator (`ExclusionPruner`) that wraps `ByDepth(0)` and re-applies the exclusion check at every depth. It delegates depth decisions entirely to `ByDepth` and lazily caches child instances the same way `ByDepth` does. `ExclusionPruner` sits at the root (depth 0), so its children receive `ByDepth(1)`, preserving the same visibility baseline as the old code.

## Limitation (existing behaviour, kept as is)
When a `tree` expression is passed, `NamedPathPruner` is used directly. Wrapping it with `ExclusionPruner` would require revisiting the `child == delegate` identity check: `ByDepth` returns `this` for both `inline` and `merge` properties, while `NamedPathPruner` only does so for `merge` (for `inline` it descends into the named subtree, since it navigates by name rather than depth).


### Testing done
Mainly added assertions to existing tests.
Not manually tested live.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
