### PR TITLE
Add nodeId scoping to getBuildLog/searchBuildLog plus getFlowNodes for discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,8 +394,9 @@ The plugin provides the following built-in tools for interacting with Jenkins:
 #### Build Information
 - `getBuild`: Retrieve a specific build or the last build of a Jenkins job.
 - `updateBuild`: Update build display name and/or description.
-- `getBuildLog`: Retrieve log lines with pagination for a specific build or the last build. Supports forward reads, end-relative reads (negative `skip`/`limit`), and cursor pagination: every response carries a `nextCursor` you can pass back as `cursor` to keep reading without re-scanning from the top. The cursor is tied to the `(job, buildNumber)` it was issued for and is rejected if used against a different build. `totalLines` is exact for end-relative reads and `-1` for forward/cursor reads (which stop as soon as they have enough lines, so the total is never computed). Reads a non-blocking snapshot, so it returns promptly even while a build is still running. If `nextCursor` is set but `hasMoreContent` is false, you've read everything written so far and the build is still going; hold onto the cursor and call again later to pick up whatever was appended in between.
-- `searchBuildLog`: Search for log lines matching a pattern (string or regex) in build logs. Reads a non-blocking snapshot (returns promptly for in-progress builds) and stops scanning early once `maxMatches` is reached.
+- `getBuildLog`: Retrieve log lines with pagination for a specific build or the last build. Supports forward reads, end-relative reads (negative `skip`/`limit`), and cursor pagination: every response carries a `nextCursor` you can pass back as `cursor` to keep reading without re-scanning from the top. The cursor is tied to the `(job, buildNumber, nodeId)` it was issued for and is rejected if used against a different job, build or node. `totalLines` is exact for end-relative reads and `-1` for forward/cursor reads (which stop as soon as they have enough lines, so the total is never computed). Reads a non-blocking snapshot, so it returns promptly even while a build is still running. If `nextCursor` is set but `hasMoreContent` is false, you've read everything written so far and the build is still going; hold onto the cursor and call again later to pick up whatever was appended in between. Pass the optional `nodeId` to read a single Pipeline step's output instead of the whole build log (see [Reading a single Pipeline step's log](#reading-a-single-pipeline-steps-log)).
+- `searchBuildLog`: Search for log lines matching a pattern (string or regex) in build logs. Reads a non-blocking snapshot (returns promptly for in-progress builds) and stops scanning early once `maxMatches` is reached. Accepts the same optional `nodeId` as `getBuildLog` to restrict the search to one Pipeline step.
+- `getFlowNodes`: List the nodes (steps and blocks) of a Pipeline build's flow graph in execution order. Each node reports `id`, `displayName`, `type`, `status`, `parentIds`, `enclosingIds`, `stageName`, `hasLog`, and `errorMessage`. Use it to discover the `nodeId` values accepted by `getBuildLog` and `searchBuildLog`. Optional `stageName` and `onlyWithLogs` filters, plus `skip`/`limit` pagination (default 100 nodes, max 1000) — large Pipelines hold thousands of nodes, so the response also carries `matched`, `totalInGraph`, and `hasMore` so you can tell how much your filters narrowed things. Fails for non-Pipeline jobs.
 - `rebuildBuild`: Re-run a build with the same parameters. For Pipeline jobs with Replay support, uses the original script; for other parameterized jobs, schedules a new build with the same parameters. Optional `buildNumber`; defaults to the last build. Returns the queue item for the new build.
 - `getReplayScripts`: Return the main script and loaded scripts of a replayable Pipeline build. Use this to inspect or modify script before calling `replayBuild`. Fails for non-Pipeline jobs. Optional `buildNumber`; defaults to the last build.
 - `replayBuild`: Run a Pipeline build again with a modified script. Provide `mainScript` (required) and optionally `loadedScripts`. Optional `buildNumber`; defaults to the last build. Fails if the build is not replayable or replay is not allowed (e.g. permissions or sandbox).
@@ -416,6 +417,65 @@ The plugin provides the following built-in tools for interacting with Jenkins:
 Each tool accepts specific parameters to customize its behavior. For detailed usage instructions and parameter descriptions, refer to the API documentation or use the MCP introspection capabilities.
 
 To use these tools, connect to the MCP server endpoint and make tool calls using your MCP client implementation.
+
+### Reading a single Pipeline step's log
+
+A multi-stage Pipeline's console log mixes every stage's output together, so answering "what failed in
+the Test stage?" means paging through everything else too. `getBuildLog` and `searchBuildLog` both take
+an optional `nodeId` that scopes the read to one node of the Pipeline flow graph.
+
+Node IDs are not guessable, so start with `getFlowNodes`:
+
+```json
+{ "jobFullName": "my-pipeline", "stageName": "Test", "onlyWithLogs": true }
+```
+
+```json
+{
+  "nodes": [
+    { "id": "8",  "displayName": "Stage : Start",  "type": "StepStartNode", "status": "SUCCESS",
+      "stageName": "Test", "hasLog": true,  "enclosingIds": ["2"],          "errorMessage": null },
+    { "id": "10", "displayName": "Print Message", "type": "StepAtomNode",  "status": "SUCCESS",
+      "stageName": "Test", "hasLog": true,  "enclosingIds": ["9","8","2"], "errorMessage": null }
+  ],
+  "skip": 0, "matched": 2, "totalInGraph": 13, "hasMore": false
+}
+```
+
+Then pass an `id` through as `nodeId`:
+
+```json
+{ "jobFullName": "my-pipeline", "nodeId": "10", "limit": 100 }
+```
+
+Notes:
+
+- **Go by `hasLog`, not by node type.** Many block boundary nodes (`node` wrappers, block ends) delegate
+  their output to the steps nested inside them and return an empty result — not an error. Others do own
+  output, including the outer `Stage : Start` in the example above, so a node's kind does not tell you
+  whether it is worth reading. Use `onlyWithLogs: true` to list just the ones that are.
+- **A stage spans several nodes.** To assemble a whole stage's output, filter by `stageName` and read each
+  node with `hasLog: true`.
+- **Filter rather than page.** Graphs routinely reach thousands of nodes, so `getFlowNodes` returns 100 at
+  a time (max 1000). `matched` versus `totalInGraph` tells you how much your filters narrowed the graph;
+  if `matched` is still huge, add `stageName` or `onlyWithLogs` instead of walking `skip` forward.
+- **Cursors are scoped.** A `nextCursor` from one node is rejected against a different node, build, or job,
+  so paginating loops cannot silently splice unrelated logs together.
+- **`errorMessage` pinpoints failures.** Combined with `status: "FAILED"`, it usually tells you which node
+  to read without fetching any log at all.
+- Both tools error if `nodeId` is supplied for a non-Pipeline build; omit it to read the whole log.
+
+### Why scope by node
+
+An end-relative read (negative `skip`/`limit`) has to make a full pass over the log to count lines before
+it can resolve the requested window, so its cost tracks the size of the whole build log. On builds with
+very large logs that pass dominates the call. Supplying `nodeId` changes what gets scanned — one node's
+byte ranges instead of every line in the build — so the cost tracks the size of that step's output rather
+than the build's.
+
+The secondary benefit is response size: one step's output instead of a whole build's, which matters when
+the consumer is an LLM paying per token.
+
 ### Enhanced Parameter Support
 
 The MCP Server Plugin now provides comprehensive support for Jenkins parameters:

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- Provides FlowNode/FlowExecution/LogAction used for per-node log reads. Only reached
+           transitively otherwise, so declare it explicitly. -->
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <optional>true</optional>

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
@@ -221,12 +221,16 @@ public class BuildLogsExtension implements McpServerExtension {
                 cursor,
                 skip,
                 limit);
-        int maxLimit = SystemProperties.getInteger(BuildLogsExtension.class.getName() + ".limit.max", 10000);
+        // Floored at 1: Integer.decode accepts "-5" rather than falling back to the default, and a
+        // negative ceiling inverts limit's sign, rerouting a forward read into the tail path.
+        int maxLimit =
+                Math.max(1, SystemProperties.getInteger(BuildLogsExtension.class.getName() + ".limit.max", 10000));
         if (Math.abs((long) limit) > maxLimit) {
             log.warn("Limit {} is too large, using the default max limit {}", limit, maxLimit);
         }
         int absLimit = (int) Math.min(Math.abs((long) limit), maxLimit);
         limit = limit < 0 ? -absLimit : absLimit;
+        skip = Math.max(skip, -MAX_LOOKBACK);
 
         Charset charset = run.getCharset();
 
@@ -257,6 +261,15 @@ public class BuildLogsExtension implements McpServerExtension {
         // the window, so we make one full pass. totalLines is exact in this branch.
         return readTail(run, charset, skip, limit, maxLimit);
     }
+
+    /**
+     * Furthest back an end-relative read may start. {@code skip} arrives unvalidated from JSON, and the
+     * tail arithmetic ({@code -skip + |limit|}, {@code total + skip - limit}) overflows near
+     * {@link Long#MIN_VALUE} — which lands on {@code hasMoreContent=true} with no cursor and no lines,
+     * the same dead end the retained-window fix exists to prevent. Starting further back than any log
+     * can reach is the same request as "from the start", so saturate rather than reject.
+     */
+    private static final long MAX_LOOKBACK = 1L << 40;
 
     /**
      * Cursor format: base64url of {@code "<buildNumber>:<byteOffset>"}. The build number is in there so
@@ -380,13 +393,36 @@ public class BuildLogsExtension implements McpServerExtension {
         long endOfSnapshot = collector.rawBytesConsumed;
 
         long resolvedSkip;
-        int resolvedLimit = Math.abs(limit);
+        // Widened like the arithmetic above: getLogLines has already clamped limit into
+        // [-maxLimit, maxLimit], but that is two frames away, and unwidened Math.abs(Integer.MIN_VALUE)
+        // stays negative rather than failing loudly.
+        int resolvedLimit = (int) Math.abs((long) limit);
         if (skip == 0) {
             resolvedSkip = Math.max(0, total - resolvedLimit);
         } else if (limit > 0) {
             resolvedSkip = Math.max(0, total + skip);
         } else {
             resolvedSkip = Math.max(0, total + skip - resolvedLimit);
+        }
+        // The ring kept only the trailing `capacity` lines, so a window clamped by maxLimit can start
+        // inside the evicted region. Sliding it forward to whatever we happen to hold would answer a
+        // different question than the one asked, and returning nothing strands the caller, so pay for a
+        // second pass and read the window as requested. Only reachable when the lookback the caller
+        // asked for exceeds the maxLimit ceiling, so the common tail read still costs one pass.
+        long earliestRetained = Math.max(0, total - capacity);
+        if (resolvedSkip < earliestRetained) {
+            // Logged at INFO, not DEBUG: this is the one path that reads the whole log twice, and an
+            // operator watching getBuildLog latency on a large build has nothing else to go on.
+            log.info(
+                    "End-relative window starts at line {} but only the last {} of {} lines were retained;"
+                            + " re-reading that window in a second pass over the log",
+                    resolvedSkip + 1,
+                    capacity,
+                    total);
+            BuildLogResponse exact = readForward(run, charset, 0L, resolvedSkip, resolvedLimit, true, resolvedSkip);
+            // readForward never counts the total; reuse the count from the pass above. On a running
+            // build that count describes the earlier snapshot, same as any other end-relative read.
+            return exact.withTotalLines(total);
         }
         long endExclusive = Math.min(resolvedSkip + resolvedLimit, total);
 
@@ -692,7 +728,18 @@ public class BuildLogsExtension implements McpServerExtension {
             long startLine,
             long endLine,
             long totalLines,
-            String nextCursor) {}
+            String nextCursor) {
+
+        /**
+         * The same response carrying an exact line count, for the one path that reads a window with
+         * {@link #readForward} (which reports {@code -1}) but already knows the total from an earlier
+         * counting pass. A copy method rather than an open-coded rebuild so a new field cannot be
+         * silently dropped here.
+         */
+        BuildLogResponse withTotalLines(long totalLines) {
+            return new BuildLogResponse(lines, hasMoreContent, startLine, endLine, totalLines, nextCursor);
+        }
+    }
 
     public record SearchLogResponse(
             String pattern,

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsExtension.java
@@ -36,6 +36,8 @@ import hudson.model.Run;
 import io.jenkins.plugins.mcp.server.McpServerExtension;
 import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
+import io.jenkins.plugins.mcp.server.extensions.util.LogSource;
+import io.jenkins.plugins.mcp.server.extensions.util.PipelineLogUtil;
 import io.jenkins.plugins.mcp.server.extensions.util.SlidingWindow;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -68,7 +70,9 @@ public class BuildLogsExtension implements McpServerExtension {
                             + " and -1 for forward reads (not computed)."
                             + " If 'nextCursor' is set but 'hasMoreContent' is false, you've read everything written"
                             + " so far but the build is still going; keep the cursor and call again later to pick up"
-                            + " whatever was appended in the meantime.",
+                            + " whatever was appended in the meantime."
+                            + " Pass 'nodeId' to read only one Pipeline step's output instead of the whole build;"
+                            + " use getFlowNodes to discover node IDs.",
             annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public BuildLogResponse getBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
@@ -88,9 +92,14 @@ public class BuildLogsExtension implements McpServerExtension {
                     Integer limit,
             @ToolParam(
                             description =
-                                    "Opaque cursor previously returned as 'nextCursor'. When set, reading resumes from that position; 'skip' is ignored and 'startLine', 'endLine' and 'totalLines' are reported as -1 (the cursor doesn't carry line numbers). The cursor is tied to the (job, buildNumber) it was issued for; passing it for a different build is rejected as invalid",
+                                    "Opaque cursor previously returned as 'nextCursor'. When set, reading resumes from that position; 'skip' is ignored and 'startLine', 'endLine' and 'totalLines' are reported as -1 (the cursor doesn't carry line numbers). The cursor is tied to the (job, buildNumber, nodeId) it was issued for; passing it for a different job, build or node is rejected as invalid",
                             required = false)
-                    String cursor) {
+                    String cursor,
+            @ToolParam(
+                            description =
+                                    "Pipeline node ID (optional, e.g. '7'). When set, only that node's own output is returned instead of the whole build log. Obtain IDs from getFlowNodes; nodes whose 'hasLog' is false return an empty result. Errors if the build is not a Pipeline run",
+                            required = false)
+                    String nodeId) {
         if (limit == null || limit == 0) {
             limit = 100;
         }
@@ -104,10 +113,10 @@ public class BuildLogsExtension implements McpServerExtension {
         return getBuildByNumberOrLast(jobFullName, buildNumber)
                 .map(build -> {
                     try {
-                        return getLogLines(build, cursorF, skipF, limitF);
-                    } catch (IllegalArgumentException e) {
-                        // Let bad-input errors (invalid or wrong-build cursor) bubble up so the caller
-                        // sees them; only unexpected failures get swallowed below.
+                        return getLogLines(resolveLogSource(build, nodeId), build.getCharset(), cursorF, skipF, limitF);
+                    } catch (IllegalArgumentException | IllegalStateException e) {
+                        // Bad input (wrong-scope cursor, unknown node, non-Pipeline build) and transient
+                        // state must reach the caller; only unexpected failures get swallowed below.
                         throw e;
                     } catch (Exception e) {
                         log.error("Error reading log for job {} build {}", jobFullName, buildNumber, e);
@@ -117,10 +126,52 @@ public class BuildLogsExtension implements McpServerExtension {
                 .orElse(null);
     }
 
+    /**
+     * The whole build when {@code nodeId} is null, otherwise that one node. A node carrying no log
+     * yields an empty source, so every read — including a cursor read — takes the same path. The lookup
+     * sits behind {@code PipelineLogUtil} so no workflow-api type appears in this class: the dependency
+     * is optional and this class must load without it.
+     */
+    private static LogSource resolveLogSource(Run<?, ?> run, String nodeId) {
+        if (nodeId == null || nodeId.isEmpty()) {
+            return LogSource.ofRun(run);
+        }
+        requirePipelineSupport();
+        return PipelineLogUtil.resolveNodeLogSource(run, nodeId);
+    }
+
+    /** Checked by name so this class carries no compile-time reference to it. */
+    private static final String PIPELINE_PROBE_CLASS = "org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner";
+
+    /**
+     * The JVM resolves constant-pool entries lazily, so {@code PipelineLogUtil} loads fine without
+     * workflow-api and only fails on the {@code instanceof FlowExecutionOwner$Executable} opening
+     * {@link PipelineLogUtil#resolveNodeLogSource}, as a {@link NoClassDefFoundError}.
+     *
+     * <p>That still reaches the client as a tool error rather than a transport failure —
+     * {@code McpToolWrapper} calls the tool through {@code Method.invoke}, which wraps anything the
+     * target throws, {@link Error} included, in an {@code InvocationTargetException} that its
+     * {@code catch (Exception)} does catch. What the caller gets is the root-cause message, which for a
+     * {@code NoClassDefFoundError} is a bare internal class name: true, and useless. Probing by name
+     * trades it for a message that names the missing plugins and the way to avoid needing them.
+     */
+    private static void requirePipelineSupport() {
+        try {
+            Class.forName(PIPELINE_PROBE_CLASS, false, BuildLogsExtension.class.getClassLoader());
+        } catch (ClassNotFoundException | LinkageError e) {
+            throw new IllegalArgumentException(
+                    "'nodeId' requires the Jenkins Pipeline plugins (workflow-api / workflow-job), which are"
+                            + " not installed on this controller. Omit 'nodeId' to read the whole build log.",
+                    e);
+        }
+    }
+
     @Tool(
             description =
                     "Search for log lines matching a pattern in a specific build or the last build of a Jenkins job. "
-                            + "Returns matching lines with their line numbers and context.",
+                            + "Returns matching lines with their line numbers and context."
+                            + " Pass 'nodeId' to search only one Pipeline step's output instead of the whole build;"
+                            + " use getFlowNodes to discover node IDs.",
             annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
     public SearchLogResponse searchBuildLog(
             @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
@@ -143,7 +194,12 @@ public class BuildLogsExtension implements McpServerExtension {
             @ToolParam(
                             description = "Number of context lines to show before and after each match (default: 0)",
                             required = false)
-                    Integer contextLines) {
+                    Integer contextLines,
+            @ToolParam(
+                            description =
+                                    "Pipeline node ID (optional, e.g. '7'). When set, only that node's own output is searched instead of the whole build log. Obtain IDs from getFlowNodes; nodes whose 'hasLog' is false yield no matches. Errors if the build is not a Pipeline run",
+                            required = false)
+                    String nodeId) {
         if (pattern == null || pattern.isEmpty()) {
             throw new IllegalArgumentException("Search pattern cannot be null or empty");
         }
@@ -160,8 +216,10 @@ public class BuildLogsExtension implements McpServerExtension {
             contextLines = 0;
         }
 
-        // Enforce limits
-        maxMatches = Math.min(maxMatches, 1000);
+        // Enforce limits. maxMatches needs the floor as much as the ceiling: at 0 the budget is full
+        // before the first line is scanned, so the first hit only flips hasMoreMatches and then stops
+        // the read, reporting "no matches, but there are more" for a pattern that is right there.
+        maxMatches = Math.min(Math.max(maxMatches, 1), 1000);
         contextLines = Math.min(Math.max(contextLines, 0), 10);
 
         final boolean useRegexF = useRegex;
@@ -172,7 +230,17 @@ public class BuildLogsExtension implements McpServerExtension {
         return getBuildByNumberOrLast(jobFullName, buildNumber)
                 .map(build -> {
                     try {
-                        return searchLogLines(build, pattern, useRegexF, ignoreCaseF, maxMatchesF, contextLinesF);
+                        return searchLogLines(
+                                resolveLogSource(build, nodeId),
+                                build.getCharset(),
+                                pattern,
+                                useRegexF,
+                                ignoreCaseF,
+                                maxMatchesF,
+                                contextLinesF);
+                    } catch (IllegalArgumentException | IllegalStateException e) {
+                        // Bad input and transient state must reach the caller; see getBuildLog.
+                        throw e;
                     } catch (Exception e) {
                         log.error("Error searching log for job {} build {}", jobFullName, buildNumber, e);
                         return null;
@@ -182,21 +250,26 @@ public class BuildLogsExtension implements McpServerExtension {
     }
 
     private SearchLogResponse searchLogLines(
-            Run<?, ?> run, String pattern, boolean useRegex, boolean ignoreCase, int maxMatches, int contextLines)
+            LogSource src,
+            Charset charset,
+            String pattern,
+            boolean useRegex,
+            boolean ignoreCase,
+            int maxMatches,
+            int contextLines)
             throws Exception {
         log.trace(
-                "searchLogLines for run {}/{} called with pattern '{}', useRegex={}, ignoreCase={}",
-                run.getParent().getName(),
-                run.getDisplayName(),
+                "searchLogLines for {} called with pattern '{}', useRegex={}, ignoreCase={}",
+                src.scopeKey(),
                 pattern,
                 useRegex,
                 ignoreCase);
 
-        try (SearchingOutputStream sos = new SearchingOutputStream(
-                pattern, useRegex, ignoreCase, maxMatches, contextLines, true, run.getCharset())) {
+        try (SearchingOutputStream sos =
+                new SearchingOutputStream(pattern, useRegex, ignoreCase, maxMatches, contextLines, true, charset)) {
             PlainTextConsoleOutputStream plain = new PlainTextConsoleOutputStream(sos);
             try {
-                drain(run.getLogText(), 0L, plain);
+                drain(src.text(), 0L, plain);
                 plain.forceEol();
                 sos.forceEol();
             } catch (StopReading ignored) {
@@ -213,18 +286,10 @@ public class BuildLogsExtension implements McpServerExtension {
         }
     }
 
-    private BuildLogResponse getLogLines(Run<?, ?> run, String cursor, long skip, int limit) throws IOException {
-        log.trace(
-                "getLogLines for run {}/{} called with cursor {}, skip {}, limit {}",
-                run.getParent().getName(),
-                run.getDisplayName(),
-                cursor,
-                skip,
-                limit);
-        // Floored at 1: Integer.decode accepts "-5" rather than falling back to the default, and a
-        // negative ceiling inverts limit's sign, rerouting a forward read into the tail path.
-        int maxLimit =
-                Math.max(1, SystemProperties.getInteger(BuildLogsExtension.class.getName() + ".limit.max", 10000));
+    private BuildLogResponse getLogLines(LogSource src, Charset charset, String cursor, long skip, int limit)
+            throws IOException {
+        log.trace("getLogLines for {} called with cursor {}, skip {}, limit {}", src.scopeKey(), cursor, skip, limit);
+        int maxLimit = maxLogLines();
         if (Math.abs((long) limit) > maxLimit) {
             log.warn("Limit {} is too large, using the default max limit {}", limit, maxLimit);
         }
@@ -232,13 +297,11 @@ public class BuildLogsExtension implements McpServerExtension {
         limit = limit < 0 ? -absLimit : absLimit;
         skip = Math.max(skip, -MAX_LOOKBACK);
 
-        Charset charset = run.getCharset();
-
         // Cursor: jump to the byte offset and ignore skip. We don't know the line numbers at an
         // arbitrary offset, so startLine/endLine/totalLines all come back as -1.
         if (cursor != null && !cursor.isEmpty()) {
-            long byteOffset = decodeCursor(cursor, run.getNumber());
-            return readForward(run, charset, byteOffset, 0L, absLimit, false, 0L);
+            long byteOffset = decodeCursor(cursor, src.scopeKey());
+            return readForward(src, charset, byteOffset, 0L, absLimit, false, 0L);
         }
 
         // Forward read: we can stop as soon as we have enough lines, so we don't bother counting the
@@ -254,12 +317,12 @@ public class BuildLogsExtension implements McpServerExtension {
                 resolvedSkip = skip;
                 resolvedLimit = absLimit;
             }
-            return readForward(run, charset, 0L, resolvedSkip, resolvedLimit, true, resolvedSkip);
+            return readForward(src, charset, 0L, resolvedSkip, resolvedLimit, true, resolvedSkip);
         }
 
         // Tail read (negative skip, or skip == 0 with negative limit): we need the total to resolve
         // the window, so we make one full pass. totalLines is exact in this branch.
-        return readTail(run, charset, skip, limit, maxLimit);
+        return readTail(src, charset, skip, limit, maxLimit);
     }
 
     /**
@@ -272,19 +335,28 @@ public class BuildLogsExtension implements McpServerExtension {
     private static final long MAX_LOOKBACK = 1L << 40;
 
     /**
-     * Cursor format: base64url of {@code "<buildNumber>:<byteOffset>"}. The build number is in there so
-     * a cursor accidentally replayed against a different build is rejected up front rather than handing
-     * back unrelated bytes from another build's log.
+     * Floored at 1: {@code Integer.decode} accepts {@code "-5"} rather than falling back to the default,
+     * and a negative ceiling inverts {@code limit}'s sign, rerouting a forward read into the tail path.
      */
-    private static String encodeCursor(int buildNumber, long byteOffset) {
-        String raw = buildNumber + ":" + byteOffset;
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.US_ASCII));
+    private static int maxLogLines() {
+        return Math.max(1, SystemProperties.getInteger(BuildLogsExtension.class.getName() + ".limit.max", 10000));
     }
 
-    private static long decodeCursor(String cursor, int expectedBuildNumber) {
+    /**
+     * Cursor format: base64url of {@code "<byteOffset>:<scopeKey>"}. The scope key identifies job, build
+     * and (when node-scoped) node, so a cursor replayed elsewhere is rejected rather than returning
+     * unrelated bytes, possibly mid-line. Offset first keeps the split unambiguous, so job names may
+     * contain colons.
+     */
+    private static String encodeCursor(String scopeKey, long byteOffset) {
+        String raw = byteOffset + ":" + scopeKey;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static long decodeCursor(String cursor, String expectedScopeKey) {
         String raw;
         try {
-            raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.US_ASCII);
+            raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid cursor", e);
         }
@@ -292,20 +364,19 @@ public class BuildLogsExtension implements McpServerExtension {
         if (sep <= 0) {
             throw new IllegalArgumentException("Invalid cursor");
         }
-        int buildNumber;
         long byteOffset;
         try {
-            buildNumber = Integer.parseInt(raw, 0, sep, 10);
-            byteOffset = Long.parseLong(raw, sep + 1, raw.length(), 10);
+            byteOffset = Long.parseLong(raw, 0, sep, 10);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid cursor", e);
         }
         if (byteOffset < 0) {
             throw new IllegalArgumentException("Invalid cursor: negative byte offset");
         }
-        if (buildNumber != expectedBuildNumber) {
-            throw new IllegalArgumentException("Cursor was issued for build #" + buildNumber + ", but build #"
-                    + expectedBuildNumber + " was requested");
+        String scopeKey = raw.substring(sep + 1);
+        if (!scopeKey.equals(expectedScopeKey)) {
+            throw new IllegalArgumentException(
+                    "Cursor was issued for " + scopeKey + ", but " + expectedScopeKey + " was requested");
         }
         return byteOffset;
     }
@@ -316,7 +387,7 @@ public class BuildLogsExtension implements McpServerExtension {
      * know there's more). Saves us from reading the whole log just to serve a "head" request.
      */
     private BuildLogResponse readForward(
-            Run<?, ?> run,
+            LogSource src,
             Charset charset,
             long startByte,
             long skip,
@@ -324,12 +395,12 @@ public class BuildLogsExtension implements McpServerExtension {
             boolean knowLineNumbers,
             long baseLine)
             throws IOException {
-        AnnotatedLargeText<?> logText = run.getLogText();
+        AnnotatedLargeText<?> logText = src.text();
         long end = logText.length();
         if (startByte >= end) {
-            // Cursor is already at the end. If the build is still going, hand back the same offset so
-            // the caller can poll for what gets appended next; if it's done, there's nothing left.
-            String nextCursor = run.isLogUpdated() ? encodeCursor(run.getNumber(), startByte) : null;
+            // Cursor is already at the end. If more output may still arrive, hand back the same offset
+            // so the caller can poll for what gets appended next; if it's done, there's nothing left.
+            String nextCursor = mayHaveMore(src, logText, startByte) ? encodeCursor(src.scopeKey(), startByte) : null;
             return new BuildLogResponse(List.of(), false, -1, -1, -1, nextCursor);
         }
         long start = System.currentTimeMillis();
@@ -342,10 +413,11 @@ public class BuildLogsExtension implements McpServerExtension {
         }
         List<String> lines = collector.lines;
         boolean more = collector.hasMoreContent;
+        long consumedEnd = startByte + collector.rawBytesConsumed;
         long nextByteOffset = more
                 ? startByte + collector.captureEndOffset
-                : (run.isLogUpdated() ? startByte + collector.rawBytesConsumed : -1);
-        String nextCursor = nextByteOffset >= 0 ? encodeCursor(run.getNumber(), nextByteOffset) : null;
+                : (mayHaveMore(src, logText, consumedEnd) ? consumedEnd : -1);
+        String nextCursor = nextByteOffset >= 0 ? encodeCursor(src.scopeKey(), nextByteOffset) : null;
         long startLine = !knowLineNumbers || lines.isEmpty() ? -1 : baseLine + 1;
         long endLine = !knowLineNumbers || lines.isEmpty() ? -1 : baseLine + lines.size();
         if (log.isDebugEnabled()) {
@@ -366,7 +438,7 @@ public class BuildLogsExtension implements McpServerExtension {
      * fall inside the requested window in a bounded ring buffer. Replaces the previous count-then-
      * extract approach (two full passes) with a single pass.
      */
-    private BuildLogResponse readTail(Run<?, ?> run, Charset charset, long skip, int limit, int maxLimit)
+    private BuildLogResponse readTail(LogSource src, Charset charset, long skip, int limit, int maxLimit)
             throws IOException {
         long theoretical;
         if (skip == 0) {
@@ -384,7 +456,7 @@ public class BuildLogsExtension implements McpServerExtension {
         }
         int capacity = (int) Math.max(1, Math.min(theoretical, maxLimit));
 
-        AnnotatedLargeText<?> logText = run.getLogText();
+        AnnotatedLargeText<?> logText = src.text();
         long start = System.currentTimeMillis();
         TailLineCollector collector = new TailLineCollector(charset, capacity);
         drain(logText, 0L, collector);
@@ -419,7 +491,7 @@ public class BuildLogsExtension implements McpServerExtension {
                     resolvedSkip + 1,
                     capacity,
                     total);
-            BuildLogResponse exact = readForward(run, charset, 0L, resolvedSkip, resolvedLimit, true, resolvedSkip);
+            BuildLogResponse exact = readForward(src, charset, 0L, resolvedSkip, resolvedLimit, true, resolvedSkip);
             // readForward never counts the total; reuse the count from the pass above. On a running
             // build that count describes the earlier snapshot, same as any other end-relative read.
             return exact.withTotalLines(total);
@@ -435,10 +507,10 @@ public class BuildLogsExtension implements McpServerExtension {
             }
         }
         boolean more = endExclusive < total;
-        // If we're caught up but the build is still going, return a cursor pointing at the end of the
-        // snapshot so the caller can come back later and pick up whatever was written in between.
-        long nextByteOffset = more ? lastEndOffset : (run.isLogUpdated() ? endOfSnapshot : -1);
-        String nextCursor = nextByteOffset >= 0 ? encodeCursor(run.getNumber(), nextByteOffset) : null;
+        // If we're caught up but more output may still arrive, return a cursor pointing at the end of
+        // the snapshot so the caller can come back later and pick up whatever was written in between.
+        long nextByteOffset = more ? lastEndOffset : (mayHaveMore(src, logText, endOfSnapshot) ? endOfSnapshot : -1);
+        String nextCursor = nextByteOffset >= 0 ? encodeCursor(src.scopeKey(), nextByteOffset) : null;
         long startLine = lines.isEmpty() ? -1 : resolvedSkip + 1;
         long endLine = lines.isEmpty() ? -1 : endExclusive;
         if (log.isDebugEnabled()) {
@@ -452,6 +524,21 @@ public class BuildLogsExtension implements McpServerExtension {
                     System.currentTimeMillis() - start);
         }
         return new BuildLogResponse(lines, more, startLine, endLine, total, nextCursor);
+    }
+
+    /**
+     * Whether a resume cursor is warranted, i.e. whether bytes beyond {@code consumedEnd} exist or could
+     * still appear.
+     *
+     * <p>Both halves matter, and both are evaluated <em>after</em> the read rather than when the {@link
+     * LogSource} was built. Liveness alone, read too early, keeps saying "still going" for a build that
+     * finished mid-read, handing back a cursor that can never yield anything. Liveness alone, read too
+     * late, misses output written between the snapshot and the source going quiet — the log is complete
+     * but we never saw its tail. Re-checking the length closes that second gap, so the cursor is dropped
+     * only when the source is finished <em>and</em> we read all of it.
+     */
+    private static boolean mayHaveMore(LogSource src, AnnotatedLargeText<?> logText, long consumedEnd) {
+        return src.live() || consumedEnd < logText.length();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/PipelineGraphExtension.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/PipelineGraphExtension.java
@@ -1,0 +1,329 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static io.jenkins.plugins.mcp.server.extensions.util.JenkinsUtil.getBuildByNumberOrLast;
+
+import hudson.model.Run;
+import io.jenkins.plugins.mcp.server.McpServerExtension;
+import io.jenkins.plugins.mcp.server.annotation.Tool;
+import io.jenkins.plugins.mcp.server.annotation.ToolParam;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+
+/**
+ * Exposes a Pipeline build's flow graph so callers can discover node IDs. Without this the {@code
+ * nodeId} parameter on the log tools is unreachable through MCP: no {@code @Exported} property on
+ * {@code WorkflowRun} walks into the flow graph.
+ */
+@OptionalExtension(requirePlugins = {"workflow-api", "workflow-job"})
+@Slf4j
+public class PipelineGraphExtension implements McpServerExtension {
+
+    private static final String STATUS_IN_PROGRESS = "IN_PROGRESS";
+    private static final String STATUS_FAILED = "FAILED";
+    private static final String STATUS_SUCCESS = "SUCCESS";
+
+    /**
+     * @param id pass as {@code nodeId} to the log tools; decimal today, but treat as opaque
+     * @param type e.g. {@code StepAtomNode}, {@code StepStartNode}, {@code StepEndNode}
+     * @param enclosingIds enclosing block IDs, innermost first
+     * @param hasLog whether this node owns log output; only these return anything from the log tools
+     */
+    public record FlowNodeInfo(
+            String id,
+            String displayName,
+            String type,
+            String status,
+            List<String> parentIds,
+            List<String> enclosingIds,
+            String stageName,
+            boolean hasLog,
+            String errorMessage) {}
+
+    private static final int DEFAULT_LIMIT = 100;
+
+    /** Graphs reach thousands of nodes in practice, so an unbounded listing is never useful. */
+    private static final int MAX_LIMIT = 1000;
+
+    /**
+     * @param matched nodes matching the filters; page through this many
+     * @param totalInGraph nodes in the whole graph, filter-independent
+     */
+    public record FlowNodesResponse(
+            List<FlowNodeInfo> nodes, long skip, int matched, int totalInGraph, boolean hasMore) {}
+
+    @Tool(
+            description = "Lists the nodes (steps and blocks) of a Pipeline build's flow graph in execution order."
+                    + " Use this to discover the 'nodeId' values accepted by getBuildLog and searchBuildLog:"
+                    + " a node is worth reading only when its 'hasLog' is true. Go by that flag rather than"
+                    + " by node type -- many block boundary nodes delegate their output to the steps nested"
+                    + " inside them, but some own output themselves."
+                    + " 'stageName' gives the enclosing stage (a parallel branch reports its stage, not the"
+                    + " branch name), so you can find the steps belonging to a particular stage and then"
+                    + " fetch just those logs."
+                    + " Real Pipelines can hold many thousands of nodes, so results are paginated:"
+                    + " compare 'matched' with 'totalInGraph' to see how much your filters narrowed the graph,"
+                    + " and prefer narrowing with 'stageName'/'onlyWithLogs' over paging through everything."
+                    + " Errors if the build is not a Pipeline run.",
+            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false))
+    public FlowNodesResponse getFlowNodes(
+            @ToolParam(description = "Job full name of the Jenkins job (e.g., 'folder/job-name')") String jobFullName,
+            @Nullable
+                    @ToolParam(
+                            description = "Build number (optional, if not provided, uses the last build)",
+                            required = false)
+                    Integer buildNumber,
+            @Nullable
+                    @ToolParam(
+                            description =
+                                    "Only return nodes inside the stage with this exact name (optional, case-sensitive)",
+                            required = false)
+                    String stageName,
+            @Nullable
+                    @ToolParam(
+                            description =
+                                    "Only return nodes that own log output, i.e. those whose 'hasLog' would be true (optional, default false)",
+                            required = false)
+                    Boolean onlyWithLogs,
+            @Nullable
+                    @ToolParam(
+                            description =
+                                    "The 0-based index to start from (optional, defaults to 0 - the first matching node)",
+                            required = false)
+                    Long skip,
+            @Nullable
+                    @ToolParam(
+                            description =
+                                    "Maximum nodes to return (optional, defaults to 100, capped at 1000). Narrow with 'stageName' or 'onlyWithLogs' rather than requesting large pages",
+                            required = false)
+                    Integer limit) {
+        boolean logsOnly = Boolean.TRUE.equals(onlyWithLogs);
+        long resolvedSkip = skip == null || skip < 0 ? 0L : skip;
+        int resolvedLimit = limit == null || limit <= 0 ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
+        return getBuildByNumberOrLast(jobFullName, buildNumber)
+                .map(build -> listNodes(build, stageName, logsOnly, resolvedSkip, resolvedLimit))
+                .orElse(null);
+    }
+
+    private FlowNodesResponse listNodes(Run<?, ?> run, String stageFilter, boolean logsOnly, long skip, int limit) {
+        FlowExecution execution = flowExecutionOf(run);
+        boolean filterByStage = stageFilter != null && !stageFilter.isEmpty();
+
+        // FlowGraphWalker visits children before parents, so the child-label index is complete by the
+        // time each node is evaluated -- no second pass needed. Building FlowNodeInfo is the expensive
+        // part (getParents/getEnclosingBlocks), so it is deferred to the page window.
+        Map<String, String> childBlockLabels = new HashMap<>();
+        List<FlowNode> candidates = new ArrayList<>();
+        int totalInGraph = 0;
+
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            totalInGraph++;
+            if (node instanceof BlockStartNode) {
+                String label = stageLabelOf(node);
+                if (label != null) {
+                    for (FlowNode parent : node.getParents()) {
+                        childBlockLabels.putIfAbsent(parent.getId(), label);
+                    }
+                }
+            }
+            if (logsOnly && node.getAction(LogAction.class) == null) {
+                continue;
+            }
+            candidates.add(node);
+        }
+
+        // Walk order is newest-first; callers reason about a build top to bottom.
+        Collections.reverse(candidates);
+
+        // The stage filter runs here rather than inside the walk. A BlockEndNode resolves its stage
+        // through its start node, whose label is indexed only once the walk reaches the block nested
+        // inside it -- later, walking newest-first. Filtering mid-walk therefore dropped end nodes that
+        // the same call reports as belonging to that stage when no filter is given, since the page is
+        // rendered after the walk with a complete index.
+        List<FlowNode> matching = candidates;
+        if (filterByStage) {
+            matching = new ArrayList<>();
+            for (FlowNode node : candidates) {
+                if (stageFilter.equals(stageNameOf(node, childBlockLabels))) {
+                    matching.add(node);
+                }
+            }
+        }
+
+        int matched = matching.size();
+        int from = (int) Math.min(skip, matched);
+        int to = (int) Math.min((long) from + limit, matched);
+        List<FlowNodeInfo> page = new ArrayList<>(to - from);
+        for (FlowNode node : matching.subList(from, to)) {
+            // Under a stage filter every surviving node already resolved to stageFilter above, so
+            // re-walking its enclosing blocks here would recompute an answer we have.
+            String stage = filterByStage ? stageFilter : stageNameOf(node, childBlockLabels);
+            page.add(toInfo(node, stage, node.getAction(LogAction.class) != null));
+        }
+        if (matched > MAX_LIMIT && !filterByStage && !logsOnly) {
+            log.debug(
+                    "{} has {} flow nodes; returning {}-{}. Callers should filter rather than page through all of them.",
+                    run.getFullDisplayName(),
+                    matched,
+                    from,
+                    to);
+        }
+        return new FlowNodesResponse(page, from, matched, totalInGraph, to < matched);
+    }
+
+    private static FlowExecution flowExecutionOf(Run<?, ?> run) {
+        if (!(run instanceof FlowExecutionOwner.Executable executable)) {
+            throw new IllegalArgumentException(
+                    "Build " + run.getFullDisplayName() + " is not a Pipeline run, so it has no flow graph.");
+        }
+        // Mirrors the same resolution in PipelineLogUtil.resolveNodeLogSource. Kept separate on
+        // purpose: that class keeps Pipeline types out of every public signature so a Pipeline-less
+        // controller can reflect over it, so it cannot host a shared helper returning a FlowExecution.
+        // Change one of these two and change the other.
+        FlowExecutionOwner owner = executable.asFlowExecutionOwner();
+        if (owner == null) {
+            throw new IllegalStateException(
+                    "Pipeline execution owner is unavailable for " + run.getFullDisplayName() + "; retry later.");
+        }
+        FlowExecution execution = owner.getOrNull();
+        if (execution == null) {
+            throw new IllegalStateException("Pipeline flow graph is not loaded for " + run.getFullDisplayName()
+                    + "; it may still be resuming. Retry later.");
+        }
+        return execution;
+    }
+
+    private static FlowNodeInfo toInfo(FlowNode node, String stageName, boolean hasLog) {
+        ErrorAction error = node.getError();
+        String status;
+        if (error != null) {
+            status = STATUS_FAILED;
+        } else if (node.isActive()) {
+            status = STATUS_IN_PROGRESS;
+        } else {
+            status = STATUS_SUCCESS;
+        }
+
+        List<String> parentIds = node.getParents().stream().map(FlowNode::getId).toList();
+        List<String> enclosingIds =
+                node.getEnclosingBlocks().stream().map(FlowNode::getId).toList();
+
+        return new FlowNodeInfo(
+                node.getId(),
+                node.getDisplayName(),
+                node.getClass().getSimpleName(),
+                status,
+                parentIds,
+                enclosingIds,
+                stageName,
+                hasLog,
+                error != null ? errorMessage(error) : null);
+    }
+
+    /**
+     * The block's stage name, or {@code null} if it does not name a stage.
+     *
+     * <p>{@link LabelAction} is not stage-specific: a {@code parallel} branch start carries one too,
+     * holding the branch name. Accepting it would report {@code stageName: "linux"} for a step inside
+     * {@code stage('Test') { parallel linux: ... }}, so a {@code stageName=Test} filter would drop that
+     * stage's actual steps. A branch start is distinguished by also carrying a {@link ThreadNameAction},
+     * which is the same test {@code pipeline-graph-analysis} uses to find stage chunks.
+     *
+     * <p>{@code getPersistentAction} avoids triggering action population on a live graph.
+     */
+    @Nullable
+    private static String stageLabelOf(FlowNode node) {
+        LabelAction label = node.getPersistentAction(LabelAction.class);
+        if (label == null || node.getPersistentAction(ThreadNameAction.class) != null) {
+            return null;
+        }
+        return label.getDisplayName();
+    }
+
+    /**
+     * A {@code stage} compiles to a nested <em>pair</em> of blocks with the {@link LabelAction} on the
+     * inner one, while the outer one owns the log. So the outer node needs the child lookup below, or it
+     * reports no stage and a {@code stageName} filter drops the very node holding the output.
+     */
+    @Nullable
+    private static String stageNameOf(FlowNode node, Map<String, String> childBlockLabels) {
+        String own = stageLabelOf(node);
+        if (own != null) {
+            return own;
+        }
+        for (BlockStartNode enclosing : node.getEnclosingBlocks()) {
+            String label = stageLabelOf(enclosing);
+            if (label != null) {
+                return label;
+            }
+        }
+        String fromChild = childBlockLabels.get(node.getId());
+        if (fromChild != null) {
+            return fromChild;
+        }
+        if (node instanceof BlockEndNode<?> endNode) {
+            // getStartNode() resolves through node storage, and on a damaged or partially loaded graph
+            // it throws rather than returning null -- it wraps both the missing-node and the IOException
+            // case in IllegalStateException. One unattributable node should not abort the whole listing.
+            BlockStartNode start;
+            try {
+                start = endNode.getStartNode();
+            } catch (IllegalStateException e) {
+                log.debug("No start node for {}, so it gets no stage attribution", node.getId(), e);
+                return null;
+            }
+            return stageNameOf(start, childBlockLabels);
+        }
+        return null;
+    }
+
+    /** {@code ErrorAction.getError()} is {@code @NonNull}, but its message may be absent. */
+    private static String errorMessage(ErrorAction error) {
+        Throwable cause = error.getError();
+        String message = cause.getMessage();
+        return message != null && !message.isEmpty()
+                ? message
+                : cause.getClass().getName();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/util/LogSource.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/util/LogSource.java
@@ -1,0 +1,64 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions.util;
+
+import hudson.console.AnnotatedLargeText;
+import hudson.model.Run;
+import java.util.function.BooleanSupplier;
+
+/**
+ * What log to read and how to scope a resume cursor to it, so the paginated read helpers serve both a
+ * whole-build log and a single Pipeline node's log without duplicating the window arithmetic.
+ *
+ * @param text raw log bytes (console notes included, so byte offsets are cursor-stable)
+ * @param liveness whether more output may still be appended; see {@link #live()}
+ * @param scopeKey identity a cursor is bound to; must distinguish job, build, and node
+ */
+public record LogSource(AnnotatedLargeText<?> text, BooleanSupplier liveness, String scopeKey) {
+
+    /**
+     * Whether more output may still be appended, answered <em>now</em> rather than when this record was
+     * built. A read of a large log takes long enough for the build or node to finish while it is in
+     * flight, and a stale {@code true} hands back a resume cursor that can never yield anything.
+     */
+    public boolean live() {
+        return liveness.getAsBoolean();
+    }
+
+    public static LogSource ofRun(Run<?, ?> run) {
+        return new LogSource(run.getLogText(), run::isLogUpdated, scopeKey(run, null));
+    }
+
+    /**
+     * The job's full name is part of the key because without it a cursor issued for one job is honoured
+     * against another, handing back a byte offset into an unrelated log.
+     */
+    public static String scopeKey(Run<?, ?> run, String nodeId) {
+        String base = run.getParent().getFullName() + "#" + run.getNumber();
+        return nodeId == null ? base : base + "/" + nodeId;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/util/PipelineLogUtil.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/util/PipelineLogUtil.java
@@ -1,0 +1,139 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions.util;
+
+import hudson.console.AnnotatedLargeText;
+import hudson.model.Run;
+import jakarta.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.kohsuke.stapler.framework.io.ByteBuffer;
+
+/**
+ * Resolves a single Pipeline node's log. All workflow-api types used for log reading are confined here:
+ * the dependency is optional, so {@code BuildLogsExtension} must not name them in its own signatures or
+ * a Pipeline-less controller would fail to load it and lose {@code getBuildLog} entirely.
+ */
+public final class PipelineLogUtil {
+
+    /**
+     * CpsFlowExecution IDs are always decimal. Enforced because the ID reaches
+     * {@code SimpleXStreamFlowNodeStorage.getNodeFile}, which interpolates it into a filename without
+     * sanitising, so {@code ../..} would escape the build directory.
+     */
+    private static final Pattern VALID_NODE_ID = Pattern.compile("[0-9]+");
+
+    private PipelineLogUtil() {}
+
+    /**
+     * Returns the node's log. A node owning none — a block boundary delegating output to the steps
+     * inside it, or a step that has not written yet — yields an empty source rather than {@code null},
+     * so callers need no special case: an empty read is just a read that found nothing, and it still
+     * goes through cursor validation and still reports liveness.
+     *
+     * @throws IllegalArgumentException for caller-fixable input (not a Pipeline run, malformed ID, no
+     *     such node)
+     * @throws IllegalStateException when the graph cannot currently be loaded, which is worth retrying
+     */
+    public static LogSource resolveNodeLogSource(Run<?, ?> run, String nodeId) {
+        if (!(run instanceof FlowExecutionOwner.Executable executable)) {
+            throw new IllegalArgumentException("Build " + run.getFullDisplayName()
+                    + " is not a Pipeline run, so it has no nodes." + " Omit 'nodeId' to read the whole build log.");
+        }
+        if (nodeId == null || !VALID_NODE_ID.matcher(nodeId).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid nodeId '" + nodeId + "': expected a decimal Pipeline node ID such as '7'."
+                            + " Use getFlowNodes to list the available IDs.");
+        }
+
+        // Deliberately not shared with PipelineGraphExtension.flowExecutionOf, which resolves an
+        // execution the same way and must keep these two messages in step by hand. A common helper
+        // would have to live somewhere both can reach, and this class cannot be it: every public
+        // signature here stays free of Pipeline types so that reflecting over the class on a
+        // controller without workflow-api does not resolve them (BuildLogsWithoutPipelineTest
+        // asserts exactly that). Duplication is the cheaper half of that trade.
+        FlowExecutionOwner owner = executable.asFlowExecutionOwner();
+        if (owner == null) {
+            throw new IllegalStateException(
+                    "Pipeline execution owner is unavailable for " + run.getFullDisplayName() + "; retry later.");
+        }
+        FlowExecution execution = owner.getOrNull();
+        if (execution == null) {
+            // Not an IllegalArgumentException: the request is well-formed, the graph just isn't loaded.
+            // Must not collapse into a "no data" success or a client cannot tell retry from give-up.
+            throw new IllegalStateException("Pipeline flow graph is not loaded for " + run.getFullDisplayName()
+                    + "; it may still be resuming. Retry later.");
+        }
+
+        FlowNode node = findNode(execution, nodeId);
+        if (node == null) {
+            throw new IllegalArgumentException("No Pipeline node '" + nodeId + "' in " + run.getFullDisplayName()
+                    + ". Use getFlowNodes to list the available IDs.");
+        }
+
+        // isActive(), not isRunning(): isRunning() means "is a current head", false for a block start
+        // whose body is still executing. isActive() means "end not yet reached", which is what "the log
+        // may still grow" requires -- and is what workflow-api's own LogStorageAction uses.
+        //
+        // Sampled *before* the snapshot below, and then held constant, which is the opposite of how a
+        // Run's log is treated. A node's AnnotatedLargeText is sized once, up front:
+        // FileLogStorage.StreamingStepLog keeps that length in a final field, so unlike a Run's
+        // file-backed text it can never report growth and a post-read length re-check sees nothing.
+        // Whether the node was still running when we took the snapshot is therefore the only signal
+        // that the snapshot may be short -- and since a node that has ended cannot restart, that is a
+        // settled fact rather than a reading that goes stale. Sampling before the snapshot means a step
+        // that finishes in between costs the caller one extra empty poll instead of losing its tail.
+        boolean activeWhenSnapshotted = node.isActive();
+
+        LogAction logAction = node.getAction(LogAction.class);
+        AnnotatedLargeText<?> text = logAction != null ? logAction.getLogText() : emptyLog(activeWhenSnapshotted);
+        return new LogSource(text, () -> activeWhenSnapshotted, LogSource.scopeKey(run, nodeId));
+    }
+
+    /**
+     * A node has no {@code LogAction} until something writes through it, so "no action" means "nothing
+     * yet", not "nothing ever" — an in-progress step can acquire one at any moment. Standing in an empty
+     * log keeps that node on the normal read path, where an active node still gets a resume cursor.
+     */
+    private static AnnotatedLargeText<?> emptyLog(boolean active) {
+        return new AnnotatedLargeText<>(new ByteBuffer(), StandardCharsets.UTF_8, !active, null);
+    }
+
+    /** Translates the checked IOException from {@code getNode} into this class's failure vocabulary. */
+    @Nullable
+    private static FlowNode findNode(FlowExecution execution, String nodeId) {
+        try {
+            return execution.getNode(nodeId);
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("Failed to load Pipeline node '" + nodeId + "': " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -69,7 +69,8 @@ public class EndPointTest {
                             "getStatus",
                             "getTestResults",
                             "getFlakyFailures",
-                            "getQueueItem");
+                            "getQueueItem",
+                            "getFlowNodes");
         }
     }
 
@@ -109,7 +110,8 @@ public class EndPointTest {
                 "getJobScm",
                 "getBuildScm",
                 "getBuildChangeSets",
-                "findJobsWithScmUrl"
+                "findJobsWithScmUrl",
+                "getFlowNodes"
             }) {
                 assertReadOnly.accept(name);
             }

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogWindowBoundsTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogWindowBoundsTest.java
@@ -40,8 +40,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junitpioneer.jupiter.SetSystemProperty;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -188,7 +193,101 @@ class BuildLogWindowBoundsTest {
         }
     }
 
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "10")
+    void nodeScopedWindowBeyondTheRetainedTailIsStillTheRequestedWindow(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createNodePayloadJob(jenkins, "bounds-node-window");
+        String nodeId = payloadNodeId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Same second-pass fallback as above, but over a *node* source, whose length is frozen at
+            // construction and whose liveness was sampled before the snapshot -- the opposite of a
+            // run's log on both counts. The whole-build cases here never exercise that combination.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), nodeId, -24L, 10);
+
+            assertThat(linesOf(result))
+                    .as("the requested window, not the retained one")
+                    .containsExactly(
+                            "PAYLOAD-LINE-7",
+                            "PAYLOAD-LINE-8",
+                            "PAYLOAD-LINE-9",
+                            "PAYLOAD-LINE-10",
+                            "PAYLOAD-LINE-11",
+                            "PAYLOAD-LINE-12",
+                            "PAYLOAD-LINE-13",
+                            "PAYLOAD-LINE-14",
+                            "PAYLOAD-LINE-15",
+                            "PAYLOAD-LINE-16");
+            assertThat(((Number) result.get("startLine")).longValue()).isEqualTo(7L);
+            assertThat(((Number) result.get("endLine")).longValue()).isEqualTo(16L);
+            assertThat(((Number) result.get("totalLines")).longValue())
+                    .as("the count from the first pass survives the second")
+                    .isEqualTo(NODE_PAYLOAD_LINES);
+            assertThat((Boolean) result.get("hasMoreContent")).isTrue();
+            assertThat((String) result.get("nextCursor"))
+                    .as("hasMoreContent=true without a cursor leaves the caller stuck")
+                    .isNotNull();
+        }
+    }
+
     // -----------------------------------------------------------------------
+
+    private static final int NODE_PAYLOAD_LINES = 30;
+
+    /** One {@code echo} of a multi-line string, so a single flow node owns all {@value #NODE_PAYLOAD_LINES} lines. */
+    private WorkflowJob createNodePayloadJob(JenkinsRule jenkins, String name) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, name);
+        project.setDefinition(new CpsFlowDefinition(
+                "String payload = 'PAYLOAD-LINE-1'\n"
+                        + "for (int i = 2; i <= " + NODE_PAYLOAD_LINES
+                        + "; i++) { payload = payload + '\\n' + 'PAYLOAD-LINE-' + i }\n"
+                        + "echo payload",
+                true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        return project;
+    }
+
+    private static String payloadNodeId(WorkflowRun build) throws Exception {
+        var execution =
+                ((FlowExecutionOwner.Executable) build).asFlowExecutionOwner().getOrNull();
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            LogAction logAction = node.getAction(LogAction.class);
+            if (logAction != null && logAction.getLogText().length() > 0) {
+                var buf = new java.io.ByteArrayOutputStream();
+                logAction.getLogText().writeLogTo(0, buf);
+                if (buf.toString(build.getCharset()).contains("PAYLOAD-LINE-" + NODE_PAYLOAD_LINES)) {
+                    return node.getId();
+                }
+            }
+        }
+        throw new AssertionError("no flow node owns the payload log");
+    }
+
+    private static Map<String, Object> getBuildLog(
+            McpSyncClient client, String jobFullName, String nodeId, Long skip, Integer limit) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        params.put("nodeId", nodeId);
+        if (skip != null) {
+            params.put("skip", skip);
+        }
+        if (limit != null) {
+            params.put("limit", limit);
+        }
+        var response = client.callTool(new McpSchema.CallToolRequest("getBuildLog", params));
+        assertThat(response.isError())
+                .as(
+                        "unexpected error: %s",
+                        ((McpSchema.TextContent) response.content().get(0)).text())
+                .isFalse();
+        return JsonPath.using(Configuration.defaultConfiguration())
+                .parse(((McpSchema.TextContent) response.content().get(0)).text())
+                .read("$.result", Map.class);
+    }
 
     private static Map<String, Object> getBuildLog(McpSyncClient client, String jobFullName, Long skip, Integer limit) {
         Map<String, Object> params = new HashMap<>();

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogWindowBoundsTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogWindowBoundsTest.java
@@ -1,0 +1,218 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Window-arithmetic edge cases in {@code getBuildLog}. Lowering {@code limit.max} from its default of
+ * 10000 makes the ceiling reachable with a small fixture.
+ */
+@WithJenkins
+class BuildLogWindowBoundsTest {
+
+    private static final String LIMIT_MAX = "io.jenkins.plugins.mcp.server.extensions.BuildLogsExtension.limit.max";
+
+    private WorkflowJob createJob(JenkinsRule jenkins, String name) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, name);
+        project.setDefinition(new CpsFlowDefinition("for (int i = 1; i <= 30; i++) { echo 'L-' + i }", true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        return project;
+    }
+
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "-5")
+    void negativeCeilingDoesNotInvertAForwardRead(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createJob(jenkins, "bounds-negative-max");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Integer.decode accepts "-5", so the default is not restored. Unfloored, a negative
+            // ceiling inverts limit's sign and reroutes this forward read into the tail path.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), 0L, 100);
+            List<String> lines = linesOf(result);
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0))
+                    .as("a forward read must start at the beginning, not the end")
+                    .isEqualTo("Started");
+            assertThat(((Number) result.get("startLine")).longValue())
+                    .as("startLine must describe a forward window")
+                    .isEqualTo(1L);
+        }
+    }
+
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "10")
+    void clampedTailWindowStaysRecoverable(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createJob(jenkins, "bounds-clamped-tail");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Requested window falls entirely inside the evicted region. Unclamped, this returned zero
+            // lines with hasMoreContent=true and nextCursor=null -- a dead end.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), -24L, 10);
+            List<String> lines = linesOf(result);
+
+            assertThat(lines)
+                    .as("a clamped window must still return the lines it retained")
+                    .isNotEmpty();
+
+            long startLine = ((Number) result.get("startLine")).longValue();
+            long endLine = ((Number) result.get("endLine")).longValue();
+            assertThat(endLine - startLine + 1)
+                    .as("reported line range must match the number of lines returned")
+                    .isEqualTo(lines.size());
+
+            boolean more = (Boolean) result.get("hasMoreContent");
+            if (more) {
+                assertThat((String) result.get("nextCursor"))
+                        .as("hasMoreContent=true without a cursor leaves the caller stuck")
+                        .isNotNull();
+            }
+        }
+    }
+
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "10")
+    void windowBeyondTheRetainedTailIsStillTheRequestedWindow(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createJob(jenkins, "bounds-exact-window");
+        List<String> full = project.getLastBuild().getLog(Integer.MAX_VALUE);
+        int total = full.size();
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // The ring buffer only retained the last 10 lines, but the caller asked for the 10 lines
+            // starting 24 from the end. Sliding the window forward to what happened to be retained
+            // would answer a different question with no indication in the response.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), -24L, 10);
+
+            assertThat(linesOf(result))
+                    .as("the requested window, not the retained one")
+                    .containsExactlyElementsOf(full.subList(total - 24, total - 14));
+            assertThat(((Number) result.get("startLine")).longValue()).isEqualTo(total - 23L);
+            assertThat(((Number) result.get("endLine")).longValue()).isEqualTo(total - 14L);
+            assertThat(((Number) result.get("totalLines")).longValue())
+                    .as("an end-relative read still reports the exact total")
+                    .isEqualTo(total);
+            assertThat((Boolean) result.get("hasMoreContent")).isTrue();
+            assertThat((String) result.get("nextCursor")).isNotNull();
+        }
+    }
+
+    // Pinned even though this is the default: the ceiling is a JVM-global system property, and the
+    // other methods here move it, so an unpinned test reads whichever value happens to be installed.
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "10000")
+    void extremeNegativeSkipDoesNotOverflowIntoADeadEnd(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createJob(jenkins, "bounds-overflow");
+        long total = project.getLastBuild().getLog(Integer.MAX_VALUE).size();
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // skip is an unvalidated Long from JSON. Both bounds have to be negative to reach the
+            // underflow: `total + skip - limit` wraps to a huge positive, so the window lands past the
+            // end of the log, past the retained-tail guard, and `resolvedSkip + limit` then overflows
+            // back to negative -- leaving hasMoreContent=true with no lines and no cursor to retry with.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), Long.MIN_VALUE, -100);
+
+            assertThat(linesOf(result))
+                    .as("a lookback longer than any log means 'from the start'")
+                    .hasSize((int) total);
+            assertThat(((Number) result.get("startLine")).longValue()).isEqualTo(1L);
+            assertThat(((Number) result.get("endLine")).longValue()).isEqualTo(total);
+            assertThat((Boolean) result.get("hasMoreContent")).isFalse();
+        }
+    }
+
+    @McpClientTest
+    @SetSystemProperty(key = LIMIT_MAX, value = "10")
+    void clampedTailReportsAccurateLineNumbers(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createJob(jenkins, "bounds-clamped-numbers");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            long total = project.getLastBuild().getLog(Integer.MAX_VALUE).size();
+
+            // Plain tail read within the ceiling: the numbers must line up exactly.
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), 0L, -10);
+            List<String> lines = linesOf(result);
+
+            assertThat(lines).hasSize(10);
+            assertThat(((Number) result.get("totalLines")).longValue()).isEqualTo(total);
+            assertThat(((Number) result.get("endLine")).longValue()).isEqualTo(total);
+            assertThat(((Number) result.get("startLine")).longValue()).isEqualTo(total - 9);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static Map<String, Object> getBuildLog(McpSyncClient client, String jobFullName, Long skip, Integer limit) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        if (skip != null) {
+            params.put("skip", skip);
+        }
+        if (limit != null) {
+            params.put("limit", limit);
+        }
+        var response = client.callTool(new McpSchema.CallToolRequest("getBuildLog", params));
+        assertThat(response.isError())
+                .as(
+                        "unexpected error: %s",
+                        ((McpSchema.TextContent) response.content().get(0)).text())
+                .isFalse();
+        return JsonPath.using(Configuration.defaultConfiguration())
+                .parse(((McpSchema.TextContent) response.content().get(0)).text())
+                .read("$.result", Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> linesOf(Map<String, Object> result) {
+        Object lines = result.get("lines");
+        return lines == null ? List.of() : new ArrayList<>((List<String>) lines);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsWithoutPipelineTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/BuildLogsWithoutPipelineTest.java
@@ -1,0 +1,236 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the log tools still work where the Pipeline plugins are <em>not</em> installed. {@code
+ * workflow-api} is optional, so a Pipeline type in a position the JVM resolves at class-load time would
+ * make a Pipeline-less controller lose {@code getBuildLog} entirely — not just the {@code nodeId}
+ * feature. Checking imports by eye is not sufficient.
+ *
+ * <p>The harness always has {@code workflow-job} on the classpath, so this hides {@code
+ * org.jenkinsci.plugins.workflow.**} behind a classloader. No {@code JenkinsRule}.
+ */
+class BuildLogsWithoutPipelineTest {
+
+    private static final String HIDDEN_PACKAGE = "org.jenkinsci.plugins.workflow.";
+
+    private static final String BUILD_LOGS = "io.jenkins.plugins.mcp.server.extensions.BuildLogsExtension";
+    private static final String LOG_SOURCE = "io.jenkins.plugins.mcp.server.extensions.util.LogSource";
+    private static final String PIPELINE_UTIL = "io.jenkins.plugins.mcp.server.extensions.util.PipelineLogUtil";
+    private static final String GRAPH_EXTENSION = "io.jenkins.plugins.mcp.server.extensions.PipelineGraphExtension";
+
+    /**
+     * Loads this plugin's classes itself so their references re-resolve here, delegates everything else
+     * to the parent, and reports {@code org.jenkinsci.plugins.workflow.**} as missing.
+     */
+    private static final class NoPipelineClassLoader extends ClassLoader {
+
+        NoPipelineClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith(HIDDEN_PACKAGE)) {
+                throw new ClassNotFoundException(name + " (hidden: simulating a controller without Pipeline)");
+            }
+            if (name.startsWith("io.jenkins.plugins.mcp.")) {
+                Class<?> already = findLoadedClass(name);
+                if (already != null) {
+                    return already;
+                }
+                synchronized (getClassLoadingLock(name)) {
+                    already = findLoadedClass(name);
+                    if (already != null) {
+                        return already;
+                    }
+                    byte[] bytes = readClassBytes(name);
+                    if (bytes != null) {
+                        Class<?> defined = defineClass(name, bytes, 0, bytes.length);
+                        if (resolve) {
+                            resolveClass(defined);
+                        }
+                        return defined;
+                    }
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private byte[] readClassBytes(String name) {
+            String resource = name.replace('.', '/') + ".class";
+            try (InputStream in = getParent().getResourceAsStream(resource)) {
+                return in == null ? null : in.readAllBytes();
+            } catch (IOException e) {
+                return null;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+
+    @Test
+    void buildLogsExtensionLoadsAndInitialisesWithoutPipelinePlugins() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+
+        // initialize=true matters: a lazily-failing <clinit> would slip past otherwise.
+        assertThatCode(() -> Class.forName(BUILD_LOGS, true, loader))
+                .as("BuildLogsExtension must load without Pipeline; a failure here means a "
+                        + "Pipeline-less controller loses getBuildLog entirely")
+                .doesNotThrowAnyException();
+
+        Class<?> extension = Class.forName(BUILD_LOGS, true, loader);
+        assertThat(extension.getClassLoader()).isSameAs(loader);
+
+        assertThatCode(() -> extension.getDeclaredConstructor().newInstance()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void toolMethodSignaturesResolveWithoutPipelinePlugins() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+        Class<?> extension = Class.forName(BUILD_LOGS, true, loader);
+
+        // Endpoint.resolveTools iterates getMethods() during registration, which resolves every
+        // parameter and return type.
+        assertThatCode(extension::getMethods)
+                .as("a Pipeline type in a method signature would break tool registration")
+                .doesNotThrowAnyException();
+
+        List<String> toolMethods = Arrays.stream(extension.getMethods())
+                .filter(m -> m.getDeclaringClass().equals(extension))
+                .map(Method::getName)
+                .filter(n -> n.equals("getBuildLog") || n.equals("searchBuildLog"))
+                .toList();
+        assertThat(toolMethods).contains("getBuildLog", "searchBuildLog");
+    }
+
+    @Test
+    void logSourceLoadsWithoutPipelinePlugins() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+
+        assertThatCode(() -> Class.forName(LOG_SOURCE, true, loader)).doesNotThrowAnyException();
+
+        Class<?> logSource = Class.forName(LOG_SOURCE, true, loader);
+        assertThatCode(logSource::getMethods).doesNotThrowAnyException();
+    }
+
+    @Test
+    void classLoaderReallyHidesPipeline() {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+
+        // Sanity check on the harness: if Pipeline were reachable, every assertion here is vacuous.
+        assertThatThrownBy(() -> Class.forName(GRAPH_EXTENSION, true, loader))
+                .as("PipelineGraphExtension names Pipeline types in its signatures, so it must fail here")
+                .isInstanceOf(NoClassDefFoundError.class);
+    }
+
+    @Test
+    void pipelineHelperLoadsButFailsOnlyWhenCalled() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+
+        // Constant-pool entries resolve lazily, so this loads cleanly with workflow-api absent -- its
+        // Pipeline types are only in method bodies. The failure is deferred to the first instruction of
+        // resolveNodeLogSource (`instanceof FlowExecutionOwner$Executable`) and is a NoClassDefFoundError,
+        // an Error that McpToolWrapper's `catch (Exception)` cannot catch. Hence the by-name guard.
+        Class<?> util = Class.forName(PIPELINE_UTIL, true, loader);
+        assertThat(util.getClassLoader()).isSameAs(loader);
+
+        // Member reflection does fail, because private findNode(FlowExecution, String) names a
+        // Pipeline type. Harmless: Jenkins only reflects over @Extension classes, and this is a utility.
+        assertThatThrownBy(util::getDeclaredMethods)
+                .as("a private helper's signature names FlowExecution, so member reflection resolves it")
+                .isInstanceOf(NoClassDefFoundError.class);
+
+        assertThatCode(() -> util.getMethod("resolveNodeLogSource", hudson.model.Run.class, String.class))
+                .as("the public API must stay free of Pipeline types in its signature")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void nodeIdIsRejectedWithAToolErrorNotAnError() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+        Class<?> extension = Class.forName(BUILD_LOGS, true, loader);
+
+        // Drives resolveLogSource, the actual path from getBuildLog. Testing requirePipelineSupport()
+        // in isolation would pass even if nothing called it.
+        Method resolveLogSource = extension.getDeclaredMethod("resolveLogSource", hudson.model.Run.class, String.class);
+        resolveLogSource.setAccessible(true);
+
+        // Null Run is fine: the guard must fire on nodeId before anything dereferences it.
+        assertThatThrownBy(() -> resolveLogSource.invoke(null, null, "7"))
+                .cause()
+                .as("must be a catchable Exception that McpToolWrapper renders as isError=true, "
+                        + "not an Error that escapes to the transport layer")
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Pipeline plugins")
+                .hasMessageContaining("Omit 'nodeId'");
+    }
+
+    @Test
+    void omittingNodeIdStillReachesTheWholeBuildPath() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+        Class<?> extension = Class.forName(BUILD_LOGS, true, loader);
+        Method resolveLogSource = extension.getDeclaredMethod("resolveLogSource", hudson.model.Run.class, String.class);
+        resolveLogSource.setAccessible(true);
+
+        // Complement of the above: without nodeId the guard must not fire, so the failure is the null
+        // Run rather than a missing-plugin complaint.
+        for (String noNode : new String[] {null, ""}) {
+            assertThatThrownBy(() -> resolveLogSource.invoke(null, null, noNode))
+                    .cause()
+                    .as("nodeId=%s must take the whole-build path, not the Pipeline guard", noNode)
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    void wholeBuildReadPathNeverTouchesThePipelineHelper() throws Exception {
+        var loader = new NoPipelineClassLoader(getClass().getClassLoader());
+        Class<?> logSource = Class.forName(LOG_SOURCE, true, loader);
+
+        // LogSource.scopeKey(run, null) is what the whole-build path calls. Exercising it proves the
+        // no-nodeId branch is reachable with Pipeline absent. (A null Run is fine: we only need the
+        // method to resolve and enter, and the NPE proves we got past class resolution.)
+        Method scopeKey = logSource.getMethod("scopeKey", hudson.model.Run.class, String.class);
+        assertThatThrownBy(() -> scopeKey.invoke(null, null, null))
+                .cause()
+                .as("expected to fail on the null Run, not on a missing Pipeline class")
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/PipelineGraphExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/PipelineGraphExtensionTest.java
@@ -1,0 +1,530 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/** Covers {@code getFlowNodes}, the discovery tool that makes {@code nodeId} usable. */
+@WithJenkins
+public class PipelineGraphExtensionTest {
+
+    private static final String TWO_STAGE_PIPELINE =
+            "stage('Build') {\n  echo 'BUILD-OUTPUT'\n}\nstage('Test') {\n  echo 'TEST-OUTPUT'\n}";
+
+    private WorkflowJob createTwoStageJob(JenkinsRule jenkins, String name) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, name);
+        project.setDefinition(new CpsFlowDefinition(TWO_STAGE_PIPELINE, true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        return project;
+    }
+
+    // -----------------------------------------------------------------------
+    // Listing
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void listsNodesInExecutionOrderWithStageNames(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-list");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> nodes = getFlowNodes(client, project.getFullName(), null, null);
+            assertThat(nodes).isNotEmpty();
+
+            for (Map<String, Object> node : nodes) {
+                assertThat((String) node.get("id")).isNotBlank();
+                assertThat((String) node.get("type")).isNotBlank();
+                assertThat((String) node.get("status")).isIn("SUCCESS", "FAILED", "IN_PROGRESS");
+                assertThat(node).containsKey("hasLog");
+            }
+
+            List<String> stageSequence = nodes.stream()
+                    .map(n -> (String) n.get("stageName"))
+                    .filter(java.util.Objects::nonNull)
+                    .distinct()
+                    .toList();
+            assertThat(stageSequence).containsExactly("Build", "Test");
+
+            // Jenkins names the echo step "Print Message", not "echo".
+            assertThat(nodes)
+                    .anySatisfy(n -> {
+                        assertThat((String) n.get("displayName")).isEqualTo("Print Message");
+                        assertThat((String) n.get("stageName")).isEqualTo("Build");
+                        assertThat((Boolean) n.get("hasLog")).isTrue();
+                    })
+                    .anySatisfy(n -> {
+                        assertThat((String) n.get("displayName")).isEqualTo("Print Message");
+                        assertThat((String) n.get("stageName")).isEqualTo("Test");
+                        assertThat((Boolean) n.get("hasLog")).isTrue();
+                    });
+
+            // The node holding a stage's log is the outer "Stage : Start" block, whose LabelAction is
+            // on its child. Unresolved, a stageName filter drops exactly that node.
+            assertThat(nodes)
+                    .filteredOn(n -> Boolean.TRUE.equals(n.get("hasLog")))
+                    .allSatisfy(n -> assertThat((String) n.get("stageName"))
+                            .as("log-bearing node %s (%s) must belong to a stage", n.get("id"), n.get("displayName"))
+                            .isNotNull());
+
+            List<Integer> ids = nodes.stream()
+                    .map(n -> Integer.parseInt((String) n.get("id")))
+                    .toList();
+            assertThat(ids).isSorted();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The round trip that closes the discovery gap
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void discoveredIdsWorkAsNodeIdInGetBuildLog(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-roundtrip");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> loggable = getFlowNodes(client, project.getFullName(), null, true);
+            assertThat(loggable).as("at least one node must own a log").isNotEmpty();
+
+            // The contract that makes nodeId reachable: every hasLog=true ID must be accepted.
+            List<String> allText = new ArrayList<>();
+            for (Map<String, Object> node : loggable) {
+                assertThat((Boolean) node.get("hasLog")).isTrue();
+                Map<String, Object> logResult = getBuildLog(client, project.getFullName(), (String) node.get("id"));
+                allText.addAll(linesOf(logResult));
+            }
+            assertThat(allText).contains("BUILD-OUTPUT", "TEST-OUTPUT");
+        }
+    }
+
+    @McpClientTest
+    void nodesReportedWithoutLogsReturnEmptyLogs(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-nolog");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> all = getFlowNodes(client, project.getFullName(), null, null);
+            List<Map<String, Object>> withoutLogs = all.stream()
+                    .filter(n -> !Boolean.TRUE.equals(n.get("hasLog")))
+                    .toList();
+            assertThat(withoutLogs)
+                    .as("a staged pipeline has block boundary nodes")
+                    .isNotEmpty();
+
+            for (Map<String, Object> node : withoutLogs) {
+                Map<String, Object> logResult = getBuildLog(client, project.getFullName(), (String) node.get("id"));
+                assertThat(linesOf(logResult))
+                        .as("node %s reported hasLog=false", node.get("id"))
+                        .isEmpty();
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Filters
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void stageFilterNarrowsToThatStage(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-stagefilter");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> testStage = getFlowNodes(client, project.getFullName(), "Test", null);
+            assertThat(testStage).isNotEmpty();
+            assertThat(testStage)
+                    .allSatisfy(n -> assertThat((String) n.get("stageName")).isEqualTo("Test"));
+
+            List<Map<String, Object>> all = getFlowNodes(client, project.getFullName(), null, null);
+            assertThat(testStage.size()).isLessThan(all.size());
+
+            // Both directions. Asserting only that every returned node says "Test" passes happily while
+            // the filter drops nodes -- and it did: a stage's end node resolves its stage through its
+            // start node, whose label was not yet indexed at the point the walk evaluated it, so the
+            // filtered listing omitted a node the unfiltered listing attributes to the same stage.
+            List<String> expected = all.stream()
+                    .filter(n -> "Test".equals(n.get("stageName")))
+                    .map(n -> (String) n.get("id"))
+                    .toList();
+            assertThat(testStage.stream().map(n -> (String) n.get("id")).toList())
+                    .as("the stage filter must return every node the unfiltered listing puts in that stage")
+                    .containsExactlyElementsOf(expected);
+
+            assertThat(getFlowNodes(client, project.getFullName(), "test", null))
+                    .isEmpty();
+            assertThat(getFlowNodes(client, project.getFullName(), "Nonexistent", null))
+                    .isEmpty();
+        }
+    }
+
+    @McpClientTest
+    void onlyWithLogsFilterMatchesTheHasLogFlag(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-logfilter");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> all = getFlowNodes(client, project.getFullName(), null, null);
+            List<Map<String, Object>> filtered = getFlowNodes(client, project.getFullName(), null, true);
+
+            long expected = all.stream()
+                    .filter(n -> Boolean.TRUE.equals(n.get("hasLog")))
+                    .count();
+            assertThat(filtered).hasSize((int) expected);
+            assertThat(filtered)
+                    .allSatisfy(n -> assertThat((Boolean) n.get("hasLog")).isTrue());
+            assertThat(filtered.size()).isLessThan(all.size());
+        }
+    }
+
+    @McpClientTest
+    void bothFiltersCombine(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createTwoStageJob(jenkins, "graph-bothfilters");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> nodes = getFlowNodes(client, project.getFullName(), "Build", true);
+            assertThat(nodes).isNotEmpty();
+            assertThat(nodes).allSatisfy(n -> {
+                assertThat((String) n.get("stageName")).isEqualTo("Build");
+                assertThat((Boolean) n.get("hasLog")).isTrue();
+            });
+
+            List<String> text = new ArrayList<>();
+            for (Map<String, Object> node : nodes) {
+                text.addAll(linesOf(getBuildLog(client, project.getFullName(), (String) node.get("id"))));
+            }
+            assertThat(text).contains("BUILD-OUTPUT");
+            assertThat(text).doesNotContain("TEST-OUTPUT");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Parallel branches are not stages
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void parallelBranchNamesAreNotReportedAsStages(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "graph-parallel");
+        project.setDefinition(new CpsFlowDefinition("""
+                stage('Test') {
+                  parallel(
+                    linux: { echo 'LINUX-OUTPUT' },
+                    windows: { echo 'WINDOWS-OUTPUT' }
+                  )
+                }
+                """, true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> all = getFlowNodes(client, project.getFullName(), null, null);
+
+            // A branch start carries a LabelAction too. Taking it as the stage reports "linux"/"windows".
+            assertThat(all)
+                    .as("no node may report a branch name as its stage")
+                    .allSatisfy(n -> assertThat((String) n.get("stageName")).isNotIn("linux", "windows"));
+
+            // ...and the steps inside the branches must still be reachable through the stage filter.
+            List<Map<String, Object>> testStage = getFlowNodes(client, project.getFullName(), "Test", true);
+            List<String> text = new ArrayList<>();
+            for (Map<String, Object> node : testStage) {
+                text.addAll(linesOf(getBuildLog(client, project.getFullName(), (String) node.get("id"))));
+            }
+            assertThat(text).contains("LINUX-OUTPUT", "WINDOWS-OUTPUT");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Failure reporting
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void failedNodeReportsFailedStatusAndMessage(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "graph-failure");
+        project.setDefinition(new CpsFlowDefinition("stage('Boom') {\n  error 'DELIBERATE-FAILURE'\n}", true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        WorkflowRun build = project.getLastBuild();
+        assertThat(build.getResult().isWorseThan(hudson.model.Result.SUCCESS)).isTrue();
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<Map<String, Object>> nodes = getFlowNodes(client, project.getFullName(), null, null);
+            assertThat(nodes).anySatisfy(n -> {
+                assertThat((String) n.get("status")).isEqualTo("FAILED");
+                assertThat((String) n.get("errorMessage")).contains("DELIBERATE-FAILURE");
+            });
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Pagination and scale
+    //
+    // Other fixtures here have ~13 nodes; real Pipelines reach thousands. This one is large enough
+    // that an unbounded response is visibly wrong.
+    // -----------------------------------------------------------------------
+
+    /** Enough nodes to exceed a page and to catch accidental O(n^2) behaviour. */
+    private WorkflowJob createManyNodeJob(JenkinsRule jenkins, String name, int steps) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, name);
+        project.setDefinition(new CpsFlowDefinition(
+                "stage('Many') {\n  for (int i = 1; i <= " + steps + "; i++) { echo 'STEP-' + i }\n}", true));
+        project.scheduleBuild2(0).get();
+        await().atMost(300, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        return project;
+    }
+
+    @McpClientTest
+    void defaultPageIsBoundedAndReportsTotals(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createManyNodeJob(jenkins, "graph-many", 150);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            Map<String, Object> first = page(client, project.getFullName(), null, null, null, null);
+
+            assertThat(nodesOf(first)).hasSize(100);
+            assertThat((Boolean) first.get("hasMore")).isTrue();
+            assertThat(((Number) first.get("matched")).intValue()).isGreaterThan(100);
+            assertThat(((Number) first.get("totalInGraph")).intValue())
+                    .isEqualTo(((Number) first.get("matched")).intValue());
+            assertThat(((Number) first.get("skip")).longValue()).isZero();
+        }
+    }
+
+    @McpClientTest
+    void pagingCoversEveryNodeExactlyOnceInOrder(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createManyNodeJob(jenkins, "graph-paging", 150);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            int matched = ((Number) page(client, project.getFullName(), null, null, null, 1)
+                            .get("matched"))
+                    .intValue();
+
+            List<String> pagedIds = new ArrayList<>();
+            long skip = 0;
+            int guard = 0;
+            while (guard++ < 100) {
+                Map<String, Object> p = page(client, project.getFullName(), null, null, skip, 40);
+                List<Map<String, Object>> nodes = nodesOf(p);
+                nodes.forEach(n -> pagedIds.add((String) n.get("id")));
+                assertThat(((Number) p.get("skip")).longValue()).isEqualTo(skip);
+                if (!Boolean.TRUE.equals(p.get("hasMore"))) {
+                    break;
+                }
+                skip += nodes.size();
+            }
+
+            // No gaps or repeats, still ordered across page joins.
+            assertThat(pagedIds).hasSize(matched).doesNotHaveDuplicates();
+            List<Integer> asInts = pagedIds.stream().map(Integer::parseInt).toList();
+            assertThat(asInts).isSorted();
+        }
+    }
+
+    @McpClientTest
+    void limitIsCappedAndSkipBeyondEndIsEmpty(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createManyNodeJob(jenkins, "graph-bounds", 150);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            Map<String, Object> huge = page(client, project.getFullName(), null, null, null, 999999);
+            int matched = ((Number) huge.get("matched")).intValue();
+            assertThat(nodesOf(huge)).hasSize(Math.min(matched, 1000));
+
+            Map<String, Object> past = page(client, project.getFullName(), null, null, (long) matched + 500, 10);
+            assertThat(nodesOf(past)).isEmpty();
+            assertThat((Boolean) past.get("hasMore")).isFalse();
+            assertThat(((Number) past.get("matched")).intValue()).isEqualTo(matched);
+
+            assertThat(nodesOf(page(client, project.getFullName(), null, null, -5L, 0)))
+                    .hasSize(Math.min(matched, 100));
+        }
+    }
+
+    @McpClientTest
+    void filtersNarrowMatchedBelowTotalInGraph(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createManyNodeJob(jenkins, "graph-narrow", 150);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            Map<String, Object> unfiltered = page(client, project.getFullName(), null, null, null, 1);
+            Map<String, Object> logsOnly = page(client, project.getFullName(), null, true, null, 1);
+
+            int total = ((Number) unfiltered.get("totalInGraph")).intValue();
+            int matchedAll = ((Number) unfiltered.get("matched")).intValue();
+            int matchedLogs = ((Number) logsOnly.get("matched")).intValue();
+
+            // totalInGraph is filter-independent; matched reflects the filter.
+            assertThat(((Number) logsOnly.get("totalInGraph")).intValue()).isEqualTo(total);
+            assertThat(matchedAll).isEqualTo(total);
+            assertThat(matchedLogs).isLessThan(total).isGreaterThan(0);
+        }
+    }
+
+    @McpClientTest
+    void largeGraphListingCompletesPromptly(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createManyNodeJob(jenkins, "graph-timing", 150);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Guards against reintroducing a per-node graph re-walk.
+            assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+                Map<String, Object> p = page(client, project.getFullName(), null, null, null, 100);
+                assertThat(nodesOf(p)).isNotEmpty();
+            });
+
+            assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+                Map<String, Object> p = page(client, project.getFullName(), "Many", true, null, 100);
+                assertThat(nodesOf(p)).isNotEmpty();
+            });
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-Pipeline build
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void nonPipelineBuildIsAnError(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        var freeStyle = jenkins.createFreeStyleProject("graph-freestyle");
+        jenkins.buildAndAssertSuccess(freeStyle);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            var response = client.callTool(
+                    new McpSchema.CallToolRequest("getFlowNodes", Map.of("jobFullName", "graph-freestyle")));
+            assertThat(response.isError()).isTrue();
+            assertThat(((McpSchema.TextContent) response.content().get(0)).text())
+                    .contains("is not a Pipeline run");
+        }
+    }
+
+    @McpClientTest
+    void unknownJobYieldsNoData(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) {
+        try (var client = builder.jenkins(jenkins).build()) {
+            var response = client.callTool(
+                    new McpSchema.CallToolRequest("getFlowNodes", Map.of("jobFullName", "does-not-exist")));
+            // Consistent with the other tools: a missing job is "no data", not an error.
+            assertThat(response.isError()).isFalse();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Node list from a default-page call. */
+    private static List<Map<String, Object>> getFlowNodes(
+            McpSyncClient client, String jobFullName, String stageName, Boolean onlyWithLogs) {
+        return nodesOf(page(client, jobFullName, stageName, onlyWithLogs, null, null));
+    }
+
+    /** Full response, so tests can assert the pagination envelope. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> page(
+            McpSyncClient client,
+            String jobFullName,
+            String stageName,
+            Boolean onlyWithLogs,
+            Long skip,
+            Integer limit) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        if (stageName != null) {
+            params.put("stageName", stageName);
+        }
+        if (onlyWithLogs != null) {
+            params.put("onlyWithLogs", onlyWithLogs);
+        }
+        if (skip != null) {
+            params.put("skip", skip);
+        }
+        if (limit != null) {
+            params.put("limit", limit);
+        }
+        var response = client.callTool(new McpSchema.CallToolRequest("getFlowNodes", params));
+        assertThat(response.isError())
+                .as("unexpected error: %s", text(response))
+                .isFalse();
+        return JsonPath.using(Configuration.defaultConfiguration())
+                .parse(text(response))
+                .read("$.result", Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> nodesOf(Map<String, Object> pageResult) {
+        Object nodes = pageResult.get("nodes");
+        return nodes == null ? List.of() : new ArrayList<>((List<Map<String, Object>>) nodes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getBuildLog(McpSyncClient client, String jobFullName, String nodeId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        params.put("nodeId", nodeId);
+        params.put("limit", 1000);
+        var response = client.callTool(new McpSchema.CallToolRequest("getBuildLog", params));
+        assertThat(response.isError())
+                .as("nodeId %s from getFlowNodes was rejected by getBuildLog: %s", nodeId, text(response))
+                .isFalse();
+        return JsonPath.using(Configuration.defaultConfiguration())
+                .parse(text(response))
+                .read("$.result", Map.class);
+    }
+
+    private static String text(McpSchema.CallToolResult response) {
+        return ((McpSchema.TextContent) response.content().get(0)).text();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> linesOf(Map<String, Object> result) {
+        Object lines = result.get("lines");
+        return lines == null ? List.of() : new ArrayList<>((List<String>) lines);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/PipelineNodeLogTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/PipelineNodeLogTest.java
@@ -1,0 +1,604 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2025, Gong Yi.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package io.jenkins.plugins.mcp.server.extensions;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import hudson.console.AnnotatedLargeText;
+import io.jenkins.plugins.mcp.server.junit.JenkinsMcpClientBuilder;
+import io.jenkins.plugins.mcp.server.junit.McpClientTest;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers the {@code nodeId} parameter on {@code getBuildLog} and {@code searchBuildLog}.
+ *
+ * <p>The payload comes from a <em>single</em> {@code echo} of a multi-line string on purpose: one
+ * {@code echo} per line puts one line in each node, which would satisfy every pagination assertion
+ * here with a single-page read.
+ */
+@WithJenkins
+public class PipelineNodeLogTest {
+
+    private static final int PAYLOAD_LINES = 30;
+
+    /** {@value #PAYLOAD_LINES} lines from one {@code echo}, wrapped in a stage so the graph also has
+     * block-boundary nodes that own no log. */
+    private static String payloadPipeline() {
+        return "stage('Payload') {\n"
+                + "  String payload = 'PAYLOAD-LINE-1'\n"
+                + "  for (int i = 2; i <= " + PAYLOAD_LINES
+                + "; i++) { payload = payload + '\\n' + 'PAYLOAD-LINE-' + i }\n"
+                + "  echo payload\n"
+                + "}";
+    }
+
+    private WorkflowJob createPayloadJob(JenkinsRule jenkins, String name) throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, name);
+        project.setDefinition(new CpsFlowDefinition(payloadPipeline(), true));
+        project.scheduleBuild2(0).get();
+        await().atMost(60, SECONDS)
+                .until(() -> project.getLastBuild() != null
+                        && !project.getLastBuild().isBuilding());
+        return project;
+    }
+
+    // -----------------------------------------------------------------------
+    // Basic read
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void nodeScopedReadReturnsOnlyThatNodesOutput(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-read");
+        String nodeId = payloadNodeId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            Map<String, Object> scoped = getBuildLog(client, project.getFullName(), nodeId, 0L, 1000, null);
+            List<String> lines = linesOf(scoped);
+
+            assertThat(lines).hasSize(PAYLOAD_LINES);
+            assertThat(lines.get(0)).isEqualTo("PAYLOAD-LINE-1");
+            assertThat(lines.get(PAYLOAD_LINES - 1)).isEqualTo("PAYLOAD-LINE-" + PAYLOAD_LINES);
+            assertThat(lines).noneMatch(l -> l.contains("Finished: SUCCESS"));
+            assertThat(lines).noneMatch(l -> l.contains("[Pipeline]"));
+
+            List<String> whole = linesOf(getBuildLog(client, project.getFullName(), null, 0L, 1000, null));
+            assertThat(whole.size()).isGreaterThan(lines.size());
+            assertThat(whole).contains("Finished: SUCCESS");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cursor pagination — genuinely multi-page now
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void nodeScopedCursorPaginationCoversTheWholeNodeLog(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-cursor");
+        String nodeId = payloadNodeId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<String> full = linesOf(getBuildLog(client, project.getFullName(), nodeId, 0L, 1000, null));
+            assertThat(full).hasSize(PAYLOAD_LINES);
+
+            // 7 does not divide 30, so the last page is partial.
+            List<String> paged = new ArrayList<>();
+            String cursor = null;
+            int pages = 0;
+            while (pages++ < 100) {
+                Map<String, Object> page = getBuildLog(client, project.getFullName(), nodeId, null, 7, cursor);
+                paged.addAll(linesOf(page));
+                cursor = (String) page.get("nextCursor");
+                if (!Boolean.TRUE.equals(page.get("hasMoreContent")) || cursor == null) {
+                    break;
+                }
+            }
+            assertThat(paged).isEqualTo(full);
+            assertThat(pages).isGreaterThan(1); // proves more than one page was actually needed
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tail read
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void nodeScopedTailReadReportsExactTotal(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-tail");
+        String nodeId = payloadNodeId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Negative limit takes the end-relative path, which knows the exact total.
+            Map<String, Object> tail = getBuildLog(client, project.getFullName(), nodeId, 0L, -5, null);
+            List<String> lines = linesOf(tail);
+
+            assertThat(lines).hasSize(5);
+            assertThat(lines.get(4)).isEqualTo("PAYLOAD-LINE-" + PAYLOAD_LINES);
+            assertThat(lines.get(0)).isEqualTo("PAYLOAD-LINE-" + (PAYLOAD_LINES - 4));
+            assertThat(((Number) tail.get("totalLines")).longValue()).isEqualTo(PAYLOAD_LINES);
+            assertThat(((Number) tail.get("endLine")).longValue()).isEqualTo(PAYLOAD_LINES);
+            assertThat(((Number) tail.get("startLine")).longValue()).isEqualTo(PAYLOAD_LINES - 4);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Omitting nodeId must not change existing behaviour
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void omittingNodeIdMatchesWholeBuildRead(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-absent");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            List<String> viaOmitted = linesOf(getBuildLog(client, project.getFullName(), null, 0L, 1000, null));
+            List<String> viaEmpty = linesOf(getBuildLog(client, project.getFullName(), "", 0L, 1000, null));
+
+            assertThat(viaEmpty).isEqualTo(viaOmitted);
+            assertThat(viaOmitted).contains("PAYLOAD-LINE-1", "Finished: SUCCESS");
+
+            List<String> paged = new ArrayList<>();
+            String cursor = null;
+            int guard = 0;
+            while (guard++ < 200) {
+                Map<String, Object> page = getBuildLog(client, project.getFullName(), null, null, 4, cursor);
+                paged.addAll(linesOf(page));
+                cursor = (String) page.get("nextCursor");
+                if (!Boolean.TRUE.equals(page.get("hasMoreContent")) || cursor == null) {
+                    break;
+                }
+            }
+            assertThat(paged).isEqualTo(viaOmitted);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cursor scope enforcement
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void cursorIsRejectedAcrossNodes(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-cursor-scope");
+        WorkflowRun build = project.getLastBuild();
+        String payloadNode = payloadNodeId(build);
+        String otherNode = otherLoggableNodeId(build, payloadNode);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            String cursor = (String) getBuildLog(client, project.getFullName(), payloadNode, 0L, 3, null)
+                    .get("nextCursor");
+            assertThat(cursor).as("a 3-of-30 page must leave a resume cursor").isNotNull();
+
+            var response = callRaw(client, "getBuildLog", params -> {
+                params.put("jobFullName", project.getFullName());
+                params.put("nodeId", otherNode);
+                params.put("cursor", cursor);
+            });
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).containsIgnoringCase("cursor was issued for");
+        }
+    }
+
+    @McpClientTest
+    void cursorIsRejectedAcrossJobs(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        // Identical pipelines means identical node IDs -- where a job-blind cursor serves wrong bytes.
+        WorkflowJob jobA = createPayloadJob(jenkins, "node-scope-a");
+        WorkflowJob jobB = createPayloadJob(jenkins, "node-scope-b");
+        String nodeA = payloadNodeId(jobA.getLastBuild());
+        String nodeB = payloadNodeId(jobB.getLastBuild());
+        assertThat(nodeA).as("fixture assumes identical graphs").isEqualTo(nodeB);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            String cursor = (String)
+                    getBuildLog(client, jobA.getFullName(), nodeA, 0L, 3, null).get("nextCursor");
+            assertThat(cursor).isNotNull();
+
+            var response = callRaw(client, "getBuildLog", params -> {
+                params.put("jobFullName", jobB.getFullName());
+                params.put("nodeId", nodeB);
+                params.put("cursor", cursor);
+            });
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).containsIgnoringCase("cursor was issued for");
+        }
+    }
+
+    @McpClientTest
+    void cursorIsRejectedEvenWhenTheTargetNodeOwnsNoLog(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-cursor-nolog");
+        WorkflowRun build = project.getLastBuild();
+        String payloadNode = payloadNodeId(build);
+        String blockNode = nodeWithoutLogId(build);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            String cursor = (String) getBuildLog(client, project.getFullName(), payloadNode, 0L, 3, null)
+                    .get("nextCursor");
+            assertThat(cursor).isNotNull();
+
+            // A log-less node short-circuits to an empty window. That must not become a hole in the
+            // scope check: a foreign cursor accepted here reads as "you have caught up" instead of
+            // "that cursor belongs to something else".
+            var response = callRaw(client, "getBuildLog", params -> {
+                params.put("jobFullName", project.getFullName());
+                params.put("nodeId", blockNode);
+                params.put("cursor", cursor);
+            });
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).containsIgnoringCase("cursor was issued for");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Rejected input
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void unknownNodeIdIsAnError(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-unknown");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            var response = callRaw(client, "getBuildLog", params -> {
+                params.put("jobFullName", project.getFullName());
+                params.put("nodeId", "99999");
+            });
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).contains("No Pipeline node '99999'");
+        }
+    }
+
+    @McpClientTest
+    void malformedNodeIdIsRejected(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-malformed");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // A traversal-shaped ID must not reach the storage layer, which interpolates it into a
+            // filename.
+            for (String bad : new String[] {"../../../../config", "7;rm", "abc", "7 ", "-1"}) {
+                var response = callRaw(client, "getBuildLog", params -> {
+                    params.put("jobFullName", project.getFullName());
+                    params.put("nodeId", bad);
+                });
+                assertThat(response.isError())
+                        .as("nodeId %s must be rejected", bad)
+                        .isTrue();
+                assertThat(textOf(response)).contains("Invalid nodeId");
+            }
+        }
+    }
+
+    @McpClientTest
+    void nodeIdOnNonPipelineBuildIsAnError(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        var freeStyle = jenkins.createFreeStyleProject("node-freestyle");
+        jenkins.buildAndAssertSuccess(freeStyle);
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            var response = callRaw(client, "getBuildLog", params -> {
+                params.put("jobFullName", "node-freestyle");
+                params.put("nodeId", "3");
+            });
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).contains("is not a Pipeline run");
+
+            assertThat(linesOf(getBuildLog(client, "node-freestyle", null, 0L, 100, null)))
+                    .isNotEmpty();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Block-boundary node owns no log
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void blockBoundaryNodeReturnsEmptyRatherThanError(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-block");
+        String blockId = nodeWithoutLogId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            Map<String, Object> result = getBuildLog(client, project.getFullName(), blockId, null, null, null);
+            assertThat(linesOf(result)).isEmpty();
+            // -1, like any other forward read: the total is never counted on this path. A log-less node
+            // reads through the same empty source as everything else rather than a special case.
+            assertThat(((Number) result.get("totalLines")).longValue()).isEqualTo(-1L);
+            assertThat((Boolean) result.get("hasMoreContent")).isFalse();
+            assertThat((String) result.get("nextCursor"))
+                    .as("a finished node with no log has nothing left to poll for")
+                    .isNull();
+
+            Map<String, Object> search = search(client, project.getFullName(), blockId, "PAYLOAD");
+            assertThat(((Number) search.get("matchCount")).intValue()).isZero();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // searchBuildLog scoping
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void searchIsScopedToTheNode(JenkinsRule jenkins, JenkinsMcpClientBuilder builder) throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-search");
+        String nodeId = payloadNodeId(project.getLastBuild());
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            // Present in the build log, absent from the echo node.
+            Map<String, Object> wholeBuild = search(client, project.getFullName(), null, "Finished: SUCCESS");
+            assertThat(((Number) wholeBuild.get("matchCount")).intValue()).isGreaterThan(0);
+
+            Map<String, Object> scoped = search(client, project.getFullName(), nodeId, "Finished: SUCCESS");
+            assertThat(((Number) scoped.get("matchCount")).intValue()).isZero();
+
+            // Line numbers are relative to the node, not the build.
+            Map<String, Object> hit = search(client, project.getFullName(), nodeId, "PAYLOAD-LINE-7");
+            assertThat(((Number) hit.get("matchCount")).intValue()).isEqualTo(1);
+            assertThat(((Number) hit.get("totalLines")).longValue()).isEqualTo(PAYLOAD_LINES);
+        }
+    }
+
+    @McpClientTest
+    void searchRejectsUnknownNodeRatherThanReturningEmpty(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = createPayloadJob(jenkins, "node-search-unknown");
+
+        try (var client = builder.jenkins(jenkins).build()) {
+            var response = callRaw(client, "searchBuildLog", params -> {
+                params.put("jobFullName", project.getFullName());
+                params.put("pattern", "PAYLOAD");
+                params.put("nodeId", "99999");
+            });
+            // Without the IllegalArgumentException carve-out this is an empty success.
+            assertThat(response.isError()).isTrue();
+            assertThat(textOf(response)).contains("No Pipeline node '99999'");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // In-progress node must not block, and must still hand back a cursor
+    // -----------------------------------------------------------------------
+
+    @McpClientTest
+    void readingARunningNodeDoesNotBlockAndKeepsPolling(JenkinsRule jenkins, JenkinsMcpClientBuilder builder)
+            throws Exception {
+        WorkflowJob project = jenkins.createProject(WorkflowJob.class, "node-running");
+        project.setDefinition(new CpsFlowDefinition(
+                "node {\n  echo 'RUNNING-MARKER'\n  sleep(time: 600, unit: 'SECONDS')\n  echo 'DONE'\n}", true));
+        project.scheduleBuild2(0);
+
+        // try/finally opens immediately: scheduleBuild2 is fire-and-forget, so a throw before the
+        // assertions would leave a build parked in a 600s sleep.
+        try {
+            await().atMost(60, SECONDS).until(() -> {
+                WorkflowRun b = project.getLastBuild();
+                return b != null
+                        && b.isBuilding()
+                        && b.getLog(200).stream().anyMatch(l -> l.contains("RUNNING-MARKER"));
+            });
+            WorkflowRun build = project.getLastBuild();
+
+            // The enclosing `node` block is still active. isRunning() got this wrong: not a current
+            // head, so it looked complete and the resume cursor was suppressed.
+            String activeBlockId = activeBlockNodeWithLogId(build);
+
+            try (var client = builder.jenkins(jenkins).build()) {
+                Map<String, Object> result = assertTimeoutPreemptively(
+                        Duration.ofSeconds(30),
+                        () -> getBuildLog(client, project.getFullName(), activeBlockId, 0L, 1000, null));
+
+                assertThat(build.isBuilding())
+                        .as("read must not have waited for the build")
+                        .isTrue();
+                assertThat(((Boolean) result.get("hasMoreContent"))).isFalse();
+                assertThat((String) result.get("nextCursor"))
+                        .as("a still-active node must return a cursor so the caller can poll for more")
+                        .isNotNull();
+            }
+        } finally {
+            WorkflowRun b = project.getLastBuild();
+            if (b != null && b.isBuilding()) {
+                b.doStop();
+                await().atMost(60, SECONDS).until(() -> !b.isBuilding());
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Graph helpers (in-process; getFlowNodes is covered by PipelineGraphExtensionTest)
+    // -----------------------------------------------------------------------
+
+    private static FlowExecution execution(WorkflowRun build) {
+        FlowExecution exec =
+                ((FlowExecutionOwner.Executable) build).asFlowExecutionOwner().getOrNull();
+        assertThat(exec).isNotNull();
+        return exec;
+    }
+
+    /**
+     * Identified by line count, not content: {@code contains("PAYLOAD-LINE-1")} also matches {@code
+     * PAYLOAD-LINE-10}, and {@link FlowGraphWalker} walks newest-first so the wrong node would win.
+     */
+    private static String payloadNodeId(WorkflowRun build) throws Exception {
+        String best = null;
+        int bestLines = 0;
+        for (FlowNode node : new FlowGraphWalker(execution(build))) {
+            LogAction la = node.getAction(LogAction.class);
+            if (la == null) {
+                continue;
+            }
+            int count = countLines(la.getLogText(), build);
+            if (count > bestLines) {
+                bestLines = count;
+                best = node.getId();
+            }
+        }
+        assertThat(best).as("no node with a log found").isNotNull();
+        assertThat(bestLines)
+                .as("fixture must put all %d payload lines in ONE node, else pagination is untested", PAYLOAD_LINES)
+                .isEqualTo(PAYLOAD_LINES);
+        return best;
+    }
+
+    private static String otherLoggableNodeId(WorkflowRun build, String excluding) {
+        for (FlowNode node : new FlowGraphWalker(execution(build))) {
+            if (node.getAction(LogAction.class) != null && !node.getId().equals(excluding)) {
+                return node.getId();
+            }
+        }
+        // A no-log node still accepts a nodeId, which is enough to prove the scope check.
+        return nodeWithoutLogId(build);
+    }
+
+    private static String nodeWithoutLogId(WorkflowRun build) {
+        for (FlowNode node : new FlowGraphWalker(execution(build))) {
+            if (node.getAction(LogAction.class) == null) {
+                return node.getId();
+            }
+        }
+        throw new AssertionError("no node without a LogAction found");
+    }
+
+    /**
+     * Active {@link BlockStartNode} with log output, asserted to have {@code isRunning() == false} --
+     * the only combination that distinguishes the two liveness predicates. A mid-execution leaf step is
+     * a current head, so a test bound to one passes with either predicate.
+     */
+    private static String activeBlockNodeWithLogId(WorkflowRun build) {
+        for (FlowNode node : new FlowGraphWalker(execution(build))) {
+            if (node instanceof BlockStartNode && node.isActive() && node.getAction(LogAction.class) != null) {
+                assertThat(node.isRunning())
+                        .as(
+                                "node %s must be active-but-not-a-head to discriminate isActive from isRunning",
+                                node.getId())
+                        .isFalse();
+                return node.getId();
+            }
+        }
+        throw new AssertionError("no active BlockStartNode with a LogAction found");
+    }
+
+    private static int countLines(AnnotatedLargeText<?> text, WorkflowRun build) throws Exception {
+        var buf = new ByteArrayOutputStream();
+        long pos = 0;
+        long end = text.length();
+        while (pos < end) {
+            long next = text.writeRawLogTo(pos, buf);
+            if (next <= pos) {
+                break;
+            }
+            pos = next;
+        }
+        String decoded = buf.toString(build.getCharset());
+        if (decoded.isEmpty()) {
+            return 0;
+        }
+        return decoded.split("\n", -1).length - (decoded.endsWith("\n") ? 1 : 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // MCP call helpers
+    // -----------------------------------------------------------------------
+
+    private static Map<String, Object> getBuildLog(
+            McpSyncClient client, String jobFullName, String nodeId, Long skip, Integer limit, String cursor) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        if (nodeId != null) {
+            params.put("nodeId", nodeId);
+        }
+        if (skip != null) {
+            params.put("skip", skip);
+        }
+        if (limit != null) {
+            params.put("limit", limit);
+        }
+        if (cursor != null) {
+            params.put("cursor", cursor);
+        }
+        return readResult(client, "getBuildLog", params);
+    }
+
+    private static Map<String, Object> search(McpSyncClient client, String jobFullName, String nodeId, String pattern) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("jobFullName", jobFullName);
+        params.put("pattern", pattern);
+        if (nodeId != null) {
+            params.put("nodeId", nodeId);
+        }
+        return readResult(client, "searchBuildLog", params);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> readResult(McpSyncClient client, String tool, Map<String, Object> params) {
+        var response = client.callTool(new McpSchema.CallToolRequest(tool, params));
+        assertThat(response.isError())
+                .as("unexpected error from %s: %s", tool, textOf(response))
+                .isFalse();
+        assertThat(response.content()).hasSize(1);
+        DocumentContext ctx =
+                JsonPath.using(Configuration.defaultConfiguration()).parse(textOf(response));
+        return ctx.read("$.result", Map.class);
+    }
+
+    private static McpSchema.CallToolResult callRaw(
+            McpSyncClient client, String tool, java.util.function.Consumer<Map<String, Object>> fill) {
+        Map<String, Object> params = new HashMap<>();
+        fill.accept(params);
+        return client.callTool(new McpSchema.CallToolRequest(tool, params));
+    }
+
+    private static String textOf(McpSchema.CallToolResult response) {
+        return ((McpSchema.TextContent) response.content().get(0)).text();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> linesOf(Map<String, Object> result) {
+        Object lines = result.get("lines");
+        return lines == null ? List.of() : new ArrayList<>((List<String>) lines);
+    }
+}


### PR DESCRIPTION
A multi-stage Pipeline's console log interleaves every stage's output, so answering "what failed in the Test stage?" means reading past everything else. `getBuildLog` and `searchBuildLog` now take an optional `nodeId` that scopes the read to a single node of the Pipeline flow graph. `getFlowNodes` lists the graph so callers can discover valid IDs.

```json
{ "jobFullName": "my-pipeline", "stageName": "Test", "onlyWithLogs": true }
```
```json
{ "nodes": [{ "id": "10", "displayName": "Print Message", "hasLog": true, ... }],
  "skip": 0, "matched": 2, "totalInGraph": 13, "hasMore": false }
```
```json
{ "jobFullName": "my-pipeline", "nodeId": "10", "limit": 100 }
```

Omitting `nodeId` is byte-for-byte the previous behaviour.

<!-- Please describe your pull request here. -->

### Notes

**Two commits.** The first fixes two pre-existing `getBuildLog` window-bounds defects
and stands alone — happy to split it into a separate PR if preferred.

- A negative `limit.max` system property inverted forward reads. `SystemProperties.getInteger`
  uses `Integer.decode`, which accepts `"-5"` rather than falling back to the default.
- Clamped tail windows became unrecoverable. `readTail`'s ring buffer retains only the
  trailing `capacity` lines, but the window and line numbers came from the full total, so a
  clamped window could fall entirely inside the evicted region: zero lines with
  `hasMoreContent=true` and `nextCursor=null`.

**Refactor.** The paginated read helpers now take a `LogSource` (log bytes, liveness
predicate, cursor identity) instead of a `Run`, so one set of helpers serves both whole-build
and per-node reads. An earlier draft forked them and the copies immediately drifted.

**Cursor scope.** Cursors now carry job, build and node. The job was previously absent, so a
cursor issued for one job was honoured against another. Cursors from earlier versions are
rejected with `Invalid cursor`.

**Optional-dependency safety.** `workflow-api` types are confined to `PipelineLogUtil` and
`PipelineGraphExtension`. Lazy class resolution means that is not sufficient alone:
`PipelineLogUtil` loads fine without `workflow-api` and fails only on the `instanceof`
opening `resolveNodeLogSource`, raising `NoClassDefFoundError` — an `Error` that
`McpToolWrapper`'s `catch (Exception)` misses. A by-name `Class.forName` probe converts
that into a tool error naming the missing plugins. `workflow-api` is also now declared
explicitly rather than relied on transitively.

**Conflict note.** This touches the exhaustive tool-name whitelist in
`EndPointTest.testListTools`, as does #215. Whichever merges second needs a one-line fix
there.

### Testing done

`mvn verify` green — 273 tests, 0 failures. New coverage:

- `PipelineNodeLogTest` (13 × 2 transports) — basic read, cursor pagination, tail read,
  node-not-found, non-Pipeline build, block-boundary empty result, in-progress non-blocking,
  cursor rejected across nodes and across jobs, malformed nodeId rejected, omitting nodeId
  unchanged, searchBuildLog scoping, searchBuildLog rejects unknown node.
- `PipelineGraphExtensionTest` (9 × 2) — listing, execution order, round-trip (IDs from
  `getFlowNodes` accepted by `getBuildLog`), stage attribution, filters, pagination, scale
  bounds.
- `BuildLogWindowBoundsTest` (3 × 2) — uses `@SetSystemProperty` to lower `limit.max` to
  a value reachable with a small fixture.
- `BuildLogsWithoutPipelineTest` (8, no `JenkinsRule`, ~0.07s) — hides
  `org.jenkinsci.plugins.workflow.**` behind a classloader; proves `BuildLogsExtension`
  loads and instantiates, tool signatures resolve, and the by-name Pipeline guard fires before
  any `Error` can escape.

Verified by mutation: reverting `isActive()`→`isRunning()`, dropping the cursor scope-key
check, removing the pagination caps, or deleting the Pipeline guard call each fails the suite.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
