### PR TITLE
feat: Add createPipeline tool (fixes #237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ For clients that prefer stateless communication without session management:
 The plugin provides the following built-in tools for interacting with Jenkins:
 
 #### Job Management
+- `createPipeline`: Create a new Jenkins pipeline job. Required parameters: `jobName` (name or full path of the pipeline) and `pipelineScript` (Jenkins pipeline script). If a job with the provided name already exists, an error is returned.
 - `getJob`: Get a Jenkins job by its full path.
 - `getJobs`: Get a paginated list of Jenkins jobs, sorted by name.
 - `triggerBuild`: Trigger a build of a job.

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -446,7 +446,8 @@ public class DefaultMcpServer implements McpServerExtension {
             if (parentItem instanceof ModifiableTopLevelItemGroup) {
                 parent = (ModifiableTopLevelItemGroup) parentItem;
             } else {
-                throw new IllegalArgumentException("Parent folder '" + parentName + "' does not exist or cannot contain jobs.");
+                throw new IllegalArgumentException(
+                        "Parent folder '" + parentName + "' does not exist or cannot contain jobs.");
             }
         }
 
@@ -454,15 +455,15 @@ public class DefaultMcpServer implements McpServerExtension {
             throw new IllegalArgumentException("A job with name '" + jobName + "' already exists.");
         }
 
-        String xml = "<?xml version='1.1' encoding='UTF-8'?>\n" +
-                "<flow-definition plugin=\"workflow-job\">\n" +
-                "  <definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\" plugin=\"workflow-cps\">\n" +
-                "    <script>" + hudson.Util.xmlEscape(pipelineScript) + "</script>\n" +
-                "    <sandbox>true</sandbox>\n" +
-                "  </definition>\n" +
-                "</flow-definition>";
+        String xml = "<?xml version='1.1' encoding='UTF-8'?>\n" + "<flow-definition plugin=\"workflow-job\">\n"
+                + "  <definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\" plugin=\"workflow-cps\">\n"
+                + "    <script>"
+                + hudson.Util.xmlEscape(pipelineScript) + "</script>\n" + "    <sandbox>true</sandbox>\n"
+                + "  </definition>\n"
+                + "</flow-definition>";
 
-        Item createdJob = parent.createProjectFromXML(name, new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        Item createdJob =
+                parent.createProjectFromXML(name, new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         return jenkins.getRootUrl() + createdJob.getUrl();
     }
 }

--- a/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
+++ b/src/main/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServer.java
@@ -50,6 +50,8 @@ import io.jenkins.plugins.mcp.server.annotation.Tool;
 import io.jenkins.plugins.mcp.server.annotation.ToolParam;
 import io.jenkins.plugins.mcp.server.tool.JenkinsMcpContext;
 import jakarta.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -58,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.model.queue.QueueItem;
 import lombok.AllArgsConstructor;
@@ -423,5 +426,43 @@ public class DefaultMcpServer implements McpServerExtension {
         }
         Queue.Item item = replayAction.run2(mainScript, scriptsToUse);
         return item != null ? (QueueItem) item : null;
+    }
+
+    @Tool(
+            description = "Create a new Jenkins pipeline job with the provided script",
+            annotations = @Tool.Annotations(readOnlyHint = false, destructiveHint = true))
+    @SneakyThrows
+    public String createPipeline(
+            @ToolParam(description = "Name (or full path) of the pipeline to create") String jobName,
+            @ToolParam(description = "The Jenkins Declarative or Scripted Pipeline script") String pipelineScript) {
+        var jenkins = Jenkins.get();
+        int lastSlash = jobName.lastIndexOf('/');
+        ModifiableTopLevelItemGroup parent = jenkins;
+        String name = jobName;
+        if (lastSlash != -1) {
+            String parentName = jobName.substring(0, lastSlash);
+            name = jobName.substring(lastSlash + 1);
+            Item parentItem = jenkins.getItemByFullName(parentName);
+            if (parentItem instanceof ModifiableTopLevelItemGroup) {
+                parent = (ModifiableTopLevelItemGroup) parentItem;
+            } else {
+                throw new IllegalArgumentException("Parent folder '" + parentName + "' does not exist or cannot contain jobs.");
+            }
+        }
+
+        if (((ItemGroup<?>) parent).getItem(name) != null) {
+            throw new IllegalArgumentException("A job with name '" + jobName + "' already exists.");
+        }
+
+        String xml = "<?xml version='1.1' encoding='UTF-8'?>\n" +
+                "<flow-definition plugin=\"workflow-job\">\n" +
+                "  <definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\" plugin=\"workflow-cps\">\n" +
+                "    <script>" + hudson.Util.xmlEscape(pipelineScript) + "</script>\n" +
+                "    <sandbox>true</sandbox>\n" +
+                "  </definition>\n" +
+                "</flow-definition>";
+
+        Item createdJob = parent.createProjectFromXML(name, new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        return jenkins.getRootUrl() + createdJob.getUrl();
     }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/EndPointTest.java
@@ -69,7 +69,8 @@ public class EndPointTest {
                             "getStatus",
                             "getTestResults",
                             "getFlakyFailures",
-                            "getQueueItem");
+                            "getQueueItem",
+                            "createPipeline");
         }
     }
 
@@ -114,7 +115,7 @@ public class EndPointTest {
                 assertReadOnly.accept(name);
             }
 
-            for (String name : new String[] {"triggerBuild", "rebuildBuild", "replayBuild"}) {
+            for (String name : new String[] {"triggerBuild", "rebuildBuild", "replayBuild", "createPipeline"}) {
                 assertDestructiveMutation.accept(name);
             }
 

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -457,4 +457,45 @@ class DefaultMcpServerTest {
             });
         }
     }
+
+    @McpClientTest
+    void testMcpToolCallCreatePipelineInFolder(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        jenkins.createFolder("my-folder");
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "createPipeline",
+                    Map.of("jobName", "my-folder/new-pipeline-job", "pipelineScript", "echo 'in folder'"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+
+            var job = jenkins.jenkins.getItemByFullName("my-folder/new-pipeline-job");
+            assertThat(job).isNotNull();
+            assertThat(job).isInstanceOf(WorkflowJob.class);
+            var definition = ((WorkflowJob) job).getDefinition();
+            assertThat(definition).isInstanceOf(CpsFlowDefinition.class);
+            assertThat(((CpsFlowDefinition) definition).getScript()).isEqualTo("echo 'in folder'");
+        }
+    }
+
+    @McpClientTest
+    void testMcpToolCallCreatePipelineInInvalidFolder(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) throws Exception {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "createPipeline",
+                    Map.of("jobName", "nonexistent-folder/new-pipeline-job", "pipelineScript", "echo 'hello'"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isTrue();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+            assertThat(response.content()).first().isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                assertThat(textContent.text()).contains("does not exist or cannot contain jobs");
+            });
+        }
+    }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -417,4 +417,44 @@ class DefaultMcpServerTest {
         jenkins.jenkins.setAuthorizationStrategy(authStrategy);
         jenkins.jenkins.save();
     }
+
+    @McpClientTest
+    void testMcpToolCallCreatePipeline(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "createPipeline", Map.of("jobName", "new-pipeline-job", "pipelineScript", "echo 'hello'"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+
+            var job = jenkins.jenkins.getItemByFullName("new-pipeline-job");
+            assertThat(job).isNotNull();
+            assertThat(job).isInstanceOf(WorkflowJob.class);
+            var definition = ((WorkflowJob) job).getDefinition();
+            assertThat(definition).isInstanceOf(CpsFlowDefinition.class);
+            assertThat(((CpsFlowDefinition) definition).getScript()).isEqualTo("echo 'hello'");
+            assertThat(((CpsFlowDefinition) definition).isSandbox()).isTrue();
+        }
+    }
+
+    @McpClientTest
+    void testMcpToolCallCreatePipelineAlreadyExists(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
+            throws Exception {
+        jenkins.createProject(WorkflowJob.class, "existing-job");
+        try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(
+                    "createPipeline", Map.of("jobName", "existing-job", "pipelineScript", "echo 'hello'"));
+
+            var response = client.callTool(request);
+            assertThat(response.isError()).isTrue();
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).type()).isEqualTo("text");
+            assertThat(response.content()).first().isInstanceOfSatisfying(McpSchema.TextContent.class, textContent -> {
+                assertThat(textContent.text()).contains("already exists");
+            });
+        }
+    }
 }

--- a/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
+++ b/src/test/java/io/jenkins/plugins/mcp/server/extensions/DefaultMcpServerTest.java
@@ -441,8 +441,8 @@ class DefaultMcpServerTest {
     }
 
     @McpClientTest
-    void testMcpToolCallCreatePipelineAlreadyExists(JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder)
-            throws Exception {
+    void testMcpToolCallCreatePipelineAlreadyExists(
+            JenkinsRule jenkins, JenkinsMcpClientBuilder jenkinsMcpClientBuilder) throws Exception {
         jenkins.createProject(WorkflowJob.class, "existing-job");
         try (var client = jenkinsMcpClientBuilder.jenkins(jenkins).build()) {
             McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(


### PR DESCRIPTION
Resolves #237. Adds a new `createPipeline` tool for the MCP Server to programmatically create Jenkins pipelines from standard scripts, complete with duplicate job verification, comprehensive automated tests, and updated plugin documentation for end-users.